### PR TITLE
add multiple client options; simplify NewClient

### DIFF
--- a/cherrygo_test.go
+++ b/cherrygo_test.go
@@ -55,7 +55,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestNewClientWithAuthVar(t *testing.T) {
-	c, _ := NewClientBase(&http.Client{}, authToken)
+	c, _ := NewClient(WithAuthToken(authToken))
 
 	if c.AuthToken != authToken {
 		t.Errorf("NewClient AuthToken = %v, expected %v", client.AuthToken, authToken)
@@ -87,7 +87,7 @@ func TestCustomUserAgent(t *testing.T) {
 	os.Setenv("CHERRY_AUTH_TOKEN", "token")
 
 	ua := "testing/1.0"
-	c, err := NewClient(SetUserAgent(ua))
+	c, err := NewClient(WithUserAgent(ua))
 
 	if err != nil {
 		t.Fatalf("NewClient() unexpected error: %v", err)


### PR DESCRIPTION
The current setup requires calls to different versions of `NewClient*()` to add an authToken or a different http client. It is a completely different command to set the user-agent, and you cannot override the URL.

This PR does the following:

* unify all of the various `NewClient*()` commands into a single one with variadic options
* provide options for setting user-agent, http client, API URL, and authToken

With this structure, we can override none, one or any combination of the above with the same call, e.g.:

```go
client := cherrygo.NewClient(WithUserAgent("someagent"), WithAuthToken("magictoken"), WithURL("https://spoofmagiccherry.com"))
```

etc.

