### PR TITLE
add targeted-to

### DIFF
--- a/ipaddress.go
+++ b/ipaddress.go
@@ -26,6 +26,7 @@ type CreateIPAddress struct {
 	ARecord    string `json:"a_record,omitempty"`
 	RoutedTo   string `json:"routed_to,omitempty"`
 	AssignedTo string `json:"assigned_to,omitempty"`
+	TargetedTo string `json:"targeted_to,omitempty"`
 }
 
 // UpdateIPAddress fields for updating IP address
@@ -34,6 +35,7 @@ type UpdateIPAddress struct {
 	ARecord    string `json:"a_record,omitempty"`
 	RoutedTo   string `json:"routed_to,omitempty"`
 	AssignedTo string `json:"assigned_to,omitempty"`
+	TargetedTo string `json:"targeted_to,omitempty"`
 }
 
 // RemoveIPAddress fields for removing IP address

--- a/servers.go
+++ b/servers.go
@@ -24,6 +24,7 @@ type IPAddresses struct {
 	Region        Region     `json:"region,omitempty"`
 	RoutedTo      RoutedTo   `json:"routed_to,omitempty"`
 	AssignedTo    AssignedTo `json:"assigned_to,omitempty"`
+	TargetedTo    AssignedTo `json:"targeted_to,omitempty"`
 	PtrRecord     string     `json:"ptr_record,omitempty"`
 	ARecord       string     `json:"a_record,omitempty"`
 	Href          string     `json:"href,omitempty"`


### PR DESCRIPTION
The existing Floating IP assignment is a bit complex. You need to find the IP address on the server, and then set that for `RoutedTo`. The addition of `targeted_to` on the API allows you to simply say, "send this Floating IP to this server". 

This PR just extends cherrygo to include `TargetedTo`.