### PR TITLE
[FIX] remove tags from server object

### DIFF
--- a/server.go
+++ b/server.go
@@ -61,22 +61,22 @@ type PowerState struct {
 
 // CreateServer fields for ordering new server
 type CreateServer struct {
-	ProjectID    string            `json:"project_id,omitempty"`
-	PlanID       string            `json:"plan_id,omitempty"`
-	Hostname     string            `json:"hostname,omitempty"`
-	Image        string            `json:"image,omitempty"`
-	Region       string            `json:"region,omitempty"`
-	SSHKeys      []string          `json:"ssh_keys"`
-	IPAddresses  []string          `json:"ip_addresses"`
-	UserData     string            `json:"user_data,omitempty"`
-	Tags         map[string]string `json:"tags,omitempty"`
-	SpotInstance bool              `json:"spot_market"`
+	ProjectID    string             `json:"project_id,omitempty"`
+	PlanID       string             `json:"plan_id,omitempty"`
+	Hostname     string             `json:"hostname,omitempty"`
+	Image        string             `json:"image,omitempty"`
+	Region       string             `json:"region,omitempty"`
+	SSHKeys      []string           `json:"ssh_keys"`
+	IPAddresses  []string           `json:"ip_addresses"`
+	UserData     string             `json:"user_data,omitempty"`
+	Tags         *map[string]string `json:"tags,omitempty"`
+	SpotInstance bool               `json:"spot_market"`
 }
 
 // UpdateServer fields for updating a server with specified tags
 type UpdateServer struct {
-	Tags map[string]string `json:"tags,omitempty"`
-	Bgp  bool              `json:"bgp"`
+	Tags *map[string]string `json:"tags,omitempty"`
+	Bgp  bool               `json:"bgp"`
 }
 
 // DeleteServer field for removing server

--- a/server_test.go
+++ b/server_test.go
@@ -129,6 +129,7 @@ func TestServer_Create(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
+	tags := map[string]string{"env": "dev"}
 	serverCreate := CreateServer{
 		PlanID:      "161",
 		Hostname:    "server-hostname",
@@ -137,7 +138,7 @@ func TestServer_Create(t *testing.T) {
 		SSHKeys:     []string{"1", "2", "3"},
 		IPAddresses: []string{"e3f75899-1db3-b794-137f-78c5ee9096af"},
 		UserData:    "dXNlcl9kYXRh",
-		Tags:        map[string]string{"env": "dev"},
+		Tags:        &tags,
 	}
 
 	server, _, err := client.Server.Create(strconv.Itoa(projectID), &serverCreate)
@@ -320,8 +321,9 @@ func TestServer_Update(t *testing.T) {
 		fmt.Fprint(writer, string(jsonBytes))
 	})
 
+	tags := map[string]string{"env": "dev"}
 	serverUpdate := UpdateServer{
-		Tags: map[string]string{"env": "dev"},
+		Tags: &tags,
 		Bgp:  false,
 	}
 


### PR DESCRIPTION
Since Cherry API require empty tags={} as body parameter for tags removal from object, I added pointers to tag fields to be able pass empty value to API.