### PR TITLE
Add server BMC and user-data for reinstalls functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+.idea/

--- a/servers.go
+++ b/servers.go
@@ -28,7 +28,10 @@ type Server struct {
 	ID               int               `json:"id,omitempty"`
 	Name             string            `json:"name,omitempty"`
 	Href             string            `json:"href,omitempty"`
+	BMC              BMC               `json:"bmc,omitempty"`
 	Hostname         string            `json:"hostname,omitempty"`
+	Username         string            `json:"username,omitempty"`
+	Password         string            `json:"password"`
 	Image            string            `json:"image,omitempty"`
 	SpotInstance     bool              `json:"spot_instance"`
 	BGP              ServerBGP         `json:"bgp,omitempty"`
@@ -45,6 +48,11 @@ type Server struct {
 	Backup           BackupStorage     `json:"backup_storage,omitempty"`
 	Created          string            `json:"created_at,omitempty"`
 	TerminationDate  string            `json:"termination_date,omitempty"`
+}
+
+type BMC struct {
+	User     string `json:"user,omitempty"`
+	Password string `json:"password,omitempty"`
 }
 
 type ReinstallServer struct {

--- a/servers.go
+++ b/servers.go
@@ -65,6 +65,7 @@ type ReinstallServerFields struct {
 	Hostname        string   `json:"hostname,omitempty"`
 	Password        string   `json:"password"`
 	SSHKeys         []string `json:"ssh_key,omitempty"`
+	UserData        string   `json:"user_data,omitempty"`
 	OSPartitionSize int      `json:"os_partition_size,omitempty"`
 }
 

--- a/servers.go
+++ b/servers.go
@@ -21,6 +21,7 @@ type ServersService interface {
 	Update(serverID int, request *UpdateServer) (Server, *Response, error)
 	Reinstall(serverID int, fields *ReinstallServerFields) (Server, *Response, error)
 	ListSSHKeys(serverID int, opts *GetOptions) ([]SSHKey, *Response, error)
+	ResetBMCPassword(serverID int) (Server, *Response, error)
 }
 
 // Server response object
@@ -163,6 +164,14 @@ func (s *ServersClient) PowerOn(serverID int) (Server, *Response, error) {
 func (s *ServersClient) Reboot(serverID int) (Server, *Response, error) {
 	action := ServerAction{
 		Type: "reboot",
+	}
+
+	return s.action(serverID, action)
+}
+
+func (s *ServersClient) ResetBMCPassword(serverID int) (Server, *Response, error) {
+	action := ServerAction{
+		Type: "reset-bmc-password",
 	}
 
 	return s.action(serverID, action)

--- a/servers_test.go
+++ b/servers_test.go
@@ -290,6 +290,40 @@ func TestServer_Reboot(t *testing.T) {
 	}
 }
 
+func TestServersClient_ResetBMCPassword(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expected := map[string]interface{}{
+		"type": "reset-bmc-password",
+	}
+
+	response := Server{
+		ID: 383531,
+	}
+
+	mux.HandleFunc("/v1/servers/383531/actions", func(writer http.ResponseWriter, request *http.Request) {
+		testMethod(t, request, http.MethodPost)
+
+		var v map[string]interface{}
+		if err := json.NewDecoder(request.Body).Decode(&v); err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+
+		if !reflect.DeepEqual(v, expected) {
+			t.Errorf("Request body\n sent %#v\n expected %#v", v, expected)
+		}
+
+		jsonBytes, _ := json.Marshal(response)
+
+		fmt.Fprint(writer, string(jsonBytes))
+	})
+
+	if _, _, err := client.Servers.ResetBMCPassword(383531); err != nil {
+		t.Errorf("Servers.ResetBMCPassword returned %+v", err)
+	}
+}
+
 func TestServer_Update(t *testing.T) {
 	setup()
 	defer teardown()

--- a/servers_test.go
+++ b/servers_test.go
@@ -14,10 +14,16 @@ func TestServer_Get(t *testing.T) {
 	defer teardown()
 
 	expected := Server{
-		ID:       383531,
-		Name:     "E5-1620v4",
-		Href:     "/servers/383531",
+		ID:   383531,
+		Name: "E5-1620v4",
+		Href: "/servers/383531",
+		BMC: BMC{
+			User:     "kuser",
+			Password: "d564!h#4s8",
+		},
 		Hostname: "server-hostname",
+		Username: "user",
+		Password: "hjas345dgf54",
 		Image:    "Ubuntu 18.04 64bit",
 		Region: Region{
 			ID:         1,


### PR DESCRIPTION
Add the necessary methods for BMC retrieval and regeneration, as well as providing user data on server re-installation.
Needed for cherryservers/cherryctl#30 , cherryservers/cherryctl#31 , cherryservers/cherryctl#32.