### PR TITLE
[ADD] BMC Password reset method

### DIFF
--- a/servers.go
+++ b/servers.go
@@ -21,6 +21,7 @@ type ServersService interface {
 	Update(serverID int, request *UpdateServer) (Server, *Response, error)
 	Reinstall(serverID int, fields *ReinstallServerFields) (Server, *Response, error)
 	ListSSHKeys(serverID int, opts *GetOptions) ([]SSHKey, *Response, error)
+	ResetBMCPassword(serverID int) (Server, *Response, error)
 }
 
 // Server response object
@@ -154,6 +155,14 @@ func (s *ServersClient) PowerOn(serverID int) (Server, *Response, error) {
 func (s *ServersClient) Reboot(serverID int) (Server, *Response, error) {
 	action := ServerAction{
 		Type: "reboot",
+	}
+
+	return s.action(serverID, action)
+}
+
+func (s *ServersClient) ResetBMCPassword(serverID int) (Server, *Response, error) {
+	action := ServerAction{
+		Type: "reset-bmc-password",
 	}
 
 	return s.action(serverID, action)

--- a/servers_test.go
+++ b/servers_test.go
@@ -284,6 +284,40 @@ func TestServer_Reboot(t *testing.T) {
 	}
 }
 
+func TestServersClient_ResetBMCPassword(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expected := map[string]interface{}{
+		"type": "reset-bmc-password",
+	}
+
+	response := Server{
+		ID: 383531,
+	}
+
+	mux.HandleFunc("/v1/servers/383531/actions", func(writer http.ResponseWriter, request *http.Request) {
+		testMethod(t, request, http.MethodPost)
+
+		var v map[string]interface{}
+		if err := json.NewDecoder(request.Body).Decode(&v); err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+
+		if !reflect.DeepEqual(v, expected) {
+			t.Errorf("Request body\n sent %#v\n expected %#v", v, expected)
+		}
+
+		jsonBytes, _ := json.Marshal(response)
+
+		fmt.Fprint(writer, string(jsonBytes))
+	})
+
+	if _, _, err := client.Servers.ResetBMCPassword(383531); err != nil {
+		t.Errorf("Servers.ResetBMCPassword returned %+v", err)
+	}
+}
+
 func TestServer_Update(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
For https://github.com/cherryservers/cherrygo/issues/42. Since BMC credential reset is a server action in the API and not bundled into ```server update```, it seemed more sensible to implement it as a separate method, like the others.