### PR TITLE
chore: set version to 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ Unset the variable to stop debugging.
 unset CHERRY_DEBUG
 ```
 
+## Release process
+
+Before release, the `libraryVersion` constant in `cherrygo.go` should be set to the correct version.
+
 ## License
 
 See the [LICENSE](LICENSE.md) file for license rights and limitations.

--- a/cherrygo.go
+++ b/cherrygo.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	libraryVersion     = "3.1.0"
+	libraryVersion     = "3.6.0"
 	apiURL             = "https://api.cherryservers.com/v1/"
 	cherryAuthTokenVar = "CHERRY_AUTH_TOKEN"
 	mediaType          = "application/json"


### PR DESCRIPTION
Set version to 3.6.0.

Also add a section in README.md to document this process.

Based on https://github.com/cherryservers/cherrygo/pull/58.