### PR TITLE
V4.0.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: golangci-lint
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.11

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,10 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - revive
+
+formatters:
+  enable:
+    - gofumpt

--- a/README.md
+++ b/README.md
@@ -8,14 +8,18 @@ You can view Cherry Servers API docs here: [https://api.cherryservers.com/doc](h
 
 ## Table of Contents
 
-- [Installation](#installation)
-- [Authentication](#authentication)
-- [Examples](#examples)
-  - [Get teams](#get-teams)
-  - [Get projects](#get-projects)
-  - [Get plans](#get-plans)
-  - [Get images](#get-images)
-  - [Request new server](#request-new-server)
+- [cherrygo](#cherrygo)
+  - [Table of Contents](#table-of-contents)
+  - [Installation](#installation)
+    - [Authentication](#authentication)
+    - [Examples](#examples)
+      - [Get teams](#get-teams)
+      - [Get projects](#get-projects)
+      - [Get plans](#get-plans)
+      - [Get images](#get-images)
+      - [Request new server](#request-new-server)
+  - [Debug](#debug)
+  - [License](#license)
 
 ## Installation
 
@@ -128,10 +132,6 @@ Unset the variable to stop debugging.
 ```
 unset CHERRY_DEBUG
 ```
-
-## Release process
-
-Before release, the `libraryVersion` constant in `cherrygo.go` should be set to the correct version.
 
 ## License
 

--- a/cherrygo.go
+++ b/cherrygo.go
@@ -15,11 +15,10 @@ import (
 )
 
 const (
-	libraryVersion     = "3.8.0"
 	apiURL             = "https://api.cherryservers.com/v1/"
 	cherryAuthTokenVar = "CHERRY_AUTH_TOKEN"
 	mediaType          = "application/json"
-	userAgent          = "cherry-agent-go/" + libraryVersion
+	userAgent          = "cherry-agent-go/"
 	cherryDebugVar     = "CHERRY_DEBUG"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/cherryservers/cherrygo/v3
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.25.4
+toolchain go1.26.1


### PR DESCRIPTION
Base for PRs targeting `v4.0.0`.

Currently:
 - Bumps Go version.
 - Adds linting.
 - Removes the manually set library version from the default user agent.

Should have:
- Automatic retries and rate limiting.
- Methods should accepts contexts (breaking change).
- Expand test coverage to include every client method, with at least happy path tests.
- Method for polling until server is deployed.
- Support pre-built plans.
- Dependabot.
- Convenience method for generating passwords when rebuilding servers.
- General hygiene/ergonomic improvements that may constitute breaking changes, e.g. fields like `Bgp` should be idiomatically renamed to `BGP`,  there's no reason for `UpdateTeam` to have all pointer fields: https://github.com/cherryservers/cherrygo/blob/4f016f96c04cee7ef08ad65c498e522217c835ef/teams.go#L87-L91 and so on.