### PR TITLE
Remove user agent version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,18 @@ You can view Cherry Servers API docs here: [https://api.cherryservers.com/doc](h
 
 ## Table of Contents
 
-- [Installation](#installation)
-- [Authentication](#authentication)
-- [Examples](#examples)
-  - [Get teams](#get-teams)
-  - [Get projects](#get-projects)
-  - [Get plans](#get-plans)
-  - [Get images](#get-images)
-  - [Request new server](#request-new-server)
+- [cherrygo](#cherrygo)
+  - [Table of Contents](#table-of-contents)
+  - [Installation](#installation)
+    - [Authentication](#authentication)
+    - [Examples](#examples)
+      - [Get teams](#get-teams)
+      - [Get projects](#get-projects)
+      - [Get plans](#get-plans)
+      - [Get images](#get-images)
+      - [Request new server](#request-new-server)
+  - [Debug](#debug)
+  - [License](#license)
 
 ## Installation
 
@@ -128,10 +132,6 @@ Unset the variable to stop debugging.
 ```
 unset CHERRY_DEBUG
 ```
-
-## Release process
-
-Before release, the `libraryVersion` constant in `cherrygo.go` should be set to the correct version.
 
 ## License
 

--- a/cherrygo.go
+++ b/cherrygo.go
@@ -15,11 +15,10 @@ import (
 )
 
 const (
-	libraryVersion     = "3.8.0"
 	apiURL             = "https://api.cherryservers.com/v1/"
 	cherryAuthTokenVar = "CHERRY_AUTH_TOKEN"
 	mediaType          = "application/json"
-	userAgent          = "cherry-agent-go/" + libraryVersion
+	userAgent          = "cherry-agent-go/"
 	cherryDebugVar     = "CHERRY_DEBUG"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/cherryservers/cherrygo/v3
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.25.4
+toolchain go1.26.1


### PR DESCRIPTION
This is something that is regularly forgotten when releasing a new version and not that relevant anyway, since applications are generally expected to set the user agent, instead of relying on the library to do so.

Based on https://github.com/cherryservers/cherrygo/pull/74, so that should be merged first.