### PR TITLE
Automatic retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,18 @@ You can view Cherry Servers API docs here: [https://api.cherryservers.com/doc](h
 
 ## Table of Contents
 
-- [Installation](#installation)
-- [Authentication](#authentication)
-- [Examples](#examples)
-  - [Get teams](#get-teams)
-  - [Get projects](#get-projects)
-  - [Get plans](#get-plans)
-  - [Get images](#get-images)
-  - [Request new server](#request-new-server)
+- [cherrygo](#cherrygo)
+  - [Table of Contents](#table-of-contents)
+  - [Installation](#installation)
+    - [Authentication](#authentication)
+    - [Examples](#examples)
+      - [Get teams](#get-teams)
+      - [Get projects](#get-projects)
+      - [Get plans](#get-plans)
+      - [Get images](#get-images)
+      - [Request new server](#request-new-server)
+  - [Debug](#debug)
+  - [License](#license)
 
 ## Installation
 
@@ -128,10 +132,6 @@ Unset the variable to stop debugging.
 ```
 unset CHERRY_DEBUG
 ```
-
-## Release process
-
-Before release, the `libraryVersion` constant in `cherrygo.go` should be set to the correct version.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ You can view Cherry Servers API docs here: [https://api.cherryservers.com/doc](h
       - [Get plans](#get-plans)
       - [Get images](#get-images)
       - [Request new server](#request-new-server)
-  - [Debug](#debug)
   - [License](#license)
 
 ## Installation
@@ -119,18 +118,6 @@ if err != nil {
 }
 
 log.Println(server.ID, server.Name, server.Hostname)
-```
-
-## Debug
-
-If you want to debug this library, set the CHERRY_DEBUG environment variable to true, which enables full API request and response logging.
-```
-export CHERRY_DEBUG="true"
-```
-
-Unset the variable to stop debugging.
-```
-unset CHERRY_DEBUG
 ```
 
 ## License

--- a/backups_test.go
+++ b/backups_test.go
@@ -36,7 +36,7 @@ func TestBackupStorage_Get(t *testing.T) {
 		}`)
 	})
 
-	backup, _, err := client.Backups.Get(123, nil)
+	backup, _, err := testClient.Backups.Get(123, nil)
 	if err != nil {
 		t.Errorf("Backups.Get returned %+v", err)
 	}
@@ -63,7 +63,7 @@ func TestBackupStorage_ListBackups(t *testing.T) {
 		]`)
 	})
 
-	backups, _, err := client.Backups.ListBackups(projectID, nil)
+	backups, _, err := testClient.Backups.ListBackups(projectID, nil)
 
 	if err != nil {
 		t.Errorf("Backups.ListBackups returned %+v", err)
@@ -101,7 +101,7 @@ func TestBackupStorage_ListPlans(t *testing.T) {
 		]`)
 	})
 
-	backupPlans, _, err := client.Backups.ListPlans(nil)
+	backupPlans, _, err := testClient.Backups.ListPlans(nil)
 
 	if err != nil {
 		t.Errorf("Backups.ListPlans returned %+v", err)
@@ -147,7 +147,7 @@ func TestBackupStorage_Create(t *testing.T) {
 		SSHKey:         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6ec8eT...",
 	}
 
-	_, _, err := client.Backups.Create(&createBackup)
+	_, _, err := testClient.Backups.Create(&createBackup)
 	if err != nil {
 		t.Errorf("Backup.Create returned %+v", err)
 	}
@@ -185,7 +185,7 @@ func TestBackupStorage_Update(t *testing.T) {
 		Password:        "abc123",
 	}
 
-	_, _, err := client.Backups.Update(&updateBackupStorage)
+	_, _, err := testClient.Backups.Update(&updateBackupStorage)
 	if err != nil {
 		t.Errorf("Backups.Update returned %+v", err)
 	}
@@ -233,7 +233,7 @@ func TestBackupStorage_UpdateMethod(t *testing.T) {
 		Whitelist:        []string{"1.1.1.1", "2.2.2.2"},
 	}
 
-	_, _, err := client.Backups.UpdateBackupMethod(&updateBackupMethod)
+	_, _, err := testClient.Backups.UpdateBackupMethod(&updateBackupMethod)
 	if err != nil {
 		t.Errorf("Backups.UpdateBackupMethod returned %+v", err)
 	}
@@ -249,7 +249,7 @@ func TestBackupStorage_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := client.Backups.Delete(123)
+	_, err := testClient.Backups.Delete(123)
 	if err != nil {
 		t.Errorf("Backups.Delete returned %+v", err)
 	}

--- a/cherrygo.go
+++ b/cherrygo.go
@@ -8,10 +8,11 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"strconv"
+
+	"github.com/cherryservers/cherrygo/v3/internal/client"
 )
 
 const (
@@ -24,8 +25,7 @@ const (
 
 // Client returns struct for client
 type Client struct {
-	client *http.Client
-	debug  bool
+	client *client.Client
 
 	BaseURL *url.URL
 
@@ -57,13 +57,9 @@ type Meta struct {
 
 // MakeRequest makes request to API
 func (c *Client) MakeRequest(method, path string, body, v interface{}) (*Response, error) {
-
 	url, _ := url.Parse(path)
 
 	u := c.BaseURL.ResolveReference(url)
-	if c.debug {
-		fmt.Printf("\nAPI Endpoint: %v\n", u)
-	}
 
 	buf := new(bytes.Buffer)
 	if body != nil {
@@ -80,18 +76,11 @@ func (c *Client) MakeRequest(method, path string, body, v interface{}) (*Respons
 		return nil, err
 	}
 
-	req.Close = true
-
 	bearer := "Bearer " + c.AuthToken
 	req.Header.Add("Authorization", bearer)
 	req.Header.Set("User-Agent", c.UserAgent)
 	req.Header.Add("Content-Type", mediaType)
 	req.Header.Add("Accept", mediaType)
-
-	if c.debug {
-		o, _ := httputil.DumpRequestOut(req, true)
-		log.Printf("\n+++++++++++++REQUEST+++++++++++++\n%s\n+++++++++++++++++++++++++++++++++", string(o))
-	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -102,11 +91,6 @@ func (c *Client) MakeRequest(method, path string, body, v interface{}) (*Respons
 
 	response := Response{Response: resp}
 	response.populateTotal()
-
-	if c.debug {
-		o, _ := httputil.DumpResponse(response.Response, true)
-		log.Printf("\n+++++++++++++RESPONSE+++++++++++++\n%s\n+++++++++++++++++++++++++++++++++", string(o))
-	}
 
 	if sc := response.StatusCode; sc >= 299 {
 		type ErrorResponse struct {
@@ -159,13 +143,13 @@ type options struct {
 	client    *http.Client
 	userAgent string
 	authToken string
+	debugDst  io.Writer
 }
 
 type ClientOpt func(*options) error
 
 // NewClient initialization
 func NewClient(opts ...ClientOpt) (*Client, error) {
-
 	parsedOpts := &options{
 		authToken: os.Getenv(cherryAuthTokenVar),
 		client:    &http.Client{},
@@ -186,9 +170,17 @@ func NewClient(opts ...ClientOpt) (*Client, error) {
 		return nil, err
 	}
 
-	c := &Client{client: parsedOpts.client, AuthToken: parsedOpts.authToken, BaseURL: url, UserAgent: parsedOpts.userAgent}
+	if parsedOpts.debugDst == nil && os.Getenv(cherryDebugVar) != "" {
+		parsedOpts.debugDst = os.Stderr
+	}
 
-	c.debug = os.Getenv(cherryDebugVar) != ""
+	c := &Client{
+		client:    client.New(client.WithHTTPClient(parsedOpts.client), client.WithDebug(parsedOpts.debugDst)),
+		AuthToken: parsedOpts.authToken,
+		BaseURL:   url,
+		UserAgent: parsedOpts.userAgent,
+	}
+
 	c.Teams = &TeamsClient{client: c}
 	c.Plans = &PlansClient{client: c}
 	c.Images = &ImagesClient{client: c}
@@ -223,7 +215,6 @@ func checkResponseForErrors(r *http.Response) *ErrorResponse {
 	}
 
 	return errR
-
 }
 
 // WithUserAgent set user agent when making requests
@@ -255,6 +246,16 @@ func WithHTTPClient(client *http.Client) ClientOpt {
 func WithAuthToken(authToken string) ClientOpt {
 	return func(c *options) error {
 		c.authToken = authToken
+		return nil
+	}
+}
+
+// WithDebug enables debug mode, which dumps logs to w.
+// Can also be enabled with the CHERRY_DEBUG environment variable, in which case logs
+// will be dumped to stderr.
+func WithDebug(w io.Writer) ClientOpt {
+	return func(c *options) error {
+		c.debugDst = w
 		return nil
 	}
 }

--- a/cherrygo.go
+++ b/cherrygo.go
@@ -15,11 +15,10 @@ import (
 )
 
 const (
-	libraryVersion     = "3.8.0"
 	apiURL             = "https://api.cherryservers.com/v1/"
 	cherryAuthTokenVar = "CHERRY_AUTH_TOKEN"
 	mediaType          = "application/json"
-	userAgent          = "cherry-agent-go/" + libraryVersion
+	userAgent          = "cherry-agent-go/"
 	cherryDebugVar     = "CHERRY_DEBUG"
 )
 

--- a/cherrygo_test.go
+++ b/cherrygo_test.go
@@ -1,20 +1,25 @@
 package cherrygo
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
-	mux       *http.ServeMux
-	client    *Client
-	server    *httptest.Server
-	teamID    int
-	projectID int
+	mux        *http.ServeMux
+	testClient *Client
+	server     *httptest.Server
+	teamID     int
+	projectID  int
 )
 
 var authToken = "myToken"
@@ -24,9 +29,9 @@ func setup() {
 
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
-	client, _ = NewClient()
+	testClient, _ = NewClient()
 	url, _ := url.Parse(server.URL)
-	client.BaseURL = url
+	testClient.BaseURL = url
 	teamID = 123
 	projectID = 321
 }
@@ -45,12 +50,12 @@ func TestNewClient(t *testing.T) {
 	setup()
 	defer teardown()
 
-	if client.BaseURL == nil || client.BaseURL.String() != server.URL {
-		t.Errorf("NewClient BaseURL = %v, expected %v", client.BaseURL, server.URL)
+	if testClient.BaseURL == nil || testClient.BaseURL.String() != server.URL {
+		t.Errorf("NewClient BaseURL = %v, expected %v", testClient.BaseURL, server.URL)
 	}
 
-	if client.UserAgent != userAgent {
-		t.Errorf("NewClient UserAgent = %v, expected %v", client.UserAgent, userAgent)
+	if testClient.UserAgent != userAgent {
+		t.Errorf("NewClient UserAgent = %v, expected %v", testClient.UserAgent, userAgent)
 	}
 }
 
@@ -58,7 +63,7 @@ func TestNewClientWithAuthVar(t *testing.T) {
 	c, _ := NewClient(WithAuthToken(authToken))
 
 	if c.AuthToken != authToken {
-		t.Errorf("NewClient AuthToken = %v, expected %v", client.AuthToken, authToken)
+		t.Errorf("NewClient AuthToken = %v, expected %v", testClient.AuthToken, authToken)
 	}
 }
 
@@ -75,7 +80,7 @@ func TestErrorResponse(t *testing.T) {
 		}`)
 	})
 
-	_, err := client.MakeRequest(http.MethodGet, "/", nil, nil)
+	_, err := testClient.MakeRequest(http.MethodGet, "/", nil, nil)
 
 	expectedErr := "Error response from API: Bad Request (error code: 400)"
 	if err.Error() != expectedErr {
@@ -88,7 +93,6 @@ func TestCustomUserAgent(t *testing.T) {
 
 	ua := "testing/1.0"
 	c, err := NewClient(WithUserAgent(ua))
-
 	if err != nil {
 		t.Fatalf("NewClient() unexpected error: %v", err)
 	}
@@ -97,4 +101,31 @@ func TestCustomUserAgent(t *testing.T) {
 	if got := c.UserAgent; got != expected {
 		t.Errorf("NewClient() UserAgent = %s; expected %s", got, expected)
 	}
+}
+
+func TestDebug(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/debug", func(w http.ResponseWriter, _ *http.Request) {
+		_, err := fmt.Fprintf(w, `{"id": 1}`)
+		require.NoError(t, err)
+	})
+
+	buf := &bytes.Buffer{}
+
+	c, err := NewClient(WithAuthToken("HIDDEN"), WithDebug(buf), WithURL(server.URL))
+	require.NoError(t, err)
+
+	_, err = c.MakeRequest("GET", "/debug", nil, &struct {
+		ID int `json:"id"`
+	}{})
+	require.NoError(t, err)
+
+	got, err := io.ReadAll(buf)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(got), "REQUEST")
+	assert.Contains(t, string(got), "RESPONSE")
+	assert.NotContains(t, string(got), "HIDDEN")
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/cherryservers/cherrygo/v3
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.25.4
+toolchain go1.26.1

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,11 @@ module github.com/cherryservers/cherrygo/v3
 go 1.25.0
 
 toolchain go1.26.1
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/images_test.go
+++ b/images_test.go
@@ -56,7 +56,7 @@ func TestImages_List(t *testing.T) {
 		]`)
 	})
 
-	images, _, err := client.Images.List("e5_1620v4", nil)
+	images, _, err := testClient.Images.List("e5_1620v4", nil)
 	if err != nil {
 		t.Errorf("Images.List returned %+v", err)
 	}

--- a/internal/client/backoff.go
+++ b/internal/client/backoff.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// BackoffFunc generates backoff delays.
+type BackoffFunc func(attempts int, resp *http.Response) time.Duration
+
+// ExponentialBackoffConfig is the configuration for exponential backoff.
+type ExponentialBackoffConfig struct {
+	Base       time.Duration
+	Cap        time.Duration
+	Multiplier float64
+}
+
+// RateLimitedExponentialBackoff returns an backoff function
+// that prioritizes `Retry-After` headers, defaulting to exponential backoff
+// if they're not found. Adds partial jitter.
+func RateLimitedExponentialBackoff(cfg ExponentialBackoffConfig) BackoffFunc {
+	return func(attempts int, req *http.Response) time.Duration {
+		backoff, ok := parseRetryAfter(req)
+		if ok {
+			return backoff
+		}
+
+		backoffSeconds := cfg.Base.Seconds() * math.Pow(cfg.Multiplier, float64(attempts))
+		backoff = time.Second * time.Duration(backoffSeconds)
+		backoff = jitter(backoff)
+
+		return min(backoff, cfg.Cap)
+	}
+}
+
+func parseRetryAfter(req *http.Response) (time.Duration, bool) {
+	if req == nil {
+		return 0, false
+	}
+
+	// Retry-After can be an integer with seconds or an HTTP date.
+	d := req.Header.Get("Retry-After")
+
+	seconds, err := strconv.Atoi(d)
+	if err == nil {
+		return time.Duration(seconds) * time.Second, true
+	}
+
+	date, err := http.ParseTime(d)
+	if err == nil {
+		return time.Until(date), true
+	}
+
+	return 0, false
+}
+
+func jitter(base time.Duration) time.Duration {
+	return time.Duration(rand.Int64N(int64(base)/2)) + base/2
+}

--- a/internal/client/backoff_test.go
+++ b/internal/client/backoff_test.go
@@ -1,0 +1,87 @@
+package client_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cherryservers/cherrygo/v3/internal/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExponentialBackoff(t *testing.T) {
+	fn := client.RateLimitedExponentialBackoff(client.ExponentialBackoffConfig{
+		Base:       2 * time.Second,
+		Cap:        60 * time.Second,
+		Multiplier: 2,
+	})
+
+	wantDelaysMin := []time.Duration{1, 2, 4, 8, 16, 32, 60, 60}
+	wantDelaysMax := []time.Duration{2, 4, 8, 16, 32, 60, 60, 60}
+
+	gotDelays := make([]time.Duration, 0, len(wantDelaysMax))
+	gotDelaysAgain := make([]time.Duration, 0, len(wantDelaysMax))
+
+	for i := range wantDelaysMax {
+		wantDelaysMax[i] = wantDelaysMax[i] * time.Second
+		wantDelaysMin[i] = wantDelaysMin[i] * time.Second
+
+		gotDelays = append(gotDelays, fn(i, nil))
+		gotDelaysAgain = append(gotDelaysAgain, fn(i, nil))
+	}
+
+	for i := range gotDelays {
+		assert.LessOrEqual(t, wantDelaysMin[i], gotDelays[i], "Backoff delay too small.")
+		assert.GreaterOrEqual(t, wantDelaysMax[i], gotDelays[i], "Backoff delay too big.")
+
+		assert.LessOrEqual(t, wantDelaysMin[i], gotDelaysAgain[i], "Backoff delay too small.")
+		assert.GreaterOrEqual(t, wantDelaysMax[i], gotDelaysAgain[i], "Backoff delay too big.")
+	}
+	assert.NotEqual(t, gotDelays, gotDelaysAgain, "Duplicate delays generated.")
+}
+
+func TestBackoffRetryAfter(t *testing.T) {
+	now := time.Now()
+
+	cases := []struct {
+		retryAfter   string
+		wantDelayMin time.Duration
+		wantDelayMax time.Duration
+	}{
+		{
+			retryAfter:   "1",
+			wantDelayMin: 1 * time.Second,
+			wantDelayMax: 1 * time.Second,
+		},
+		{
+			retryAfter:   now.Add(time.Second * 30).UTC().Format(http.TimeFormat),
+			wantDelayMin: 25 * time.Second,
+			wantDelayMax: 30 * time.Second,
+		},
+		{
+			retryAfter:   "",
+			wantDelayMin: 1 * time.Second,
+			wantDelayMax: 2 * time.Second,
+		},
+	}
+
+	fn := client.RateLimitedExponentialBackoff(client.ExponentialBackoffConfig{
+		Base:       2 * time.Second,
+		Cap:        60 * time.Second,
+		Multiplier: 2,
+	})
+
+	for _, td := range cases {
+		t.Run(td.retryAfter, func(t *testing.T) {
+			head := make(http.Header)
+			head.Add("Retry-After", td.retryAfter)
+			resp := &http.Response{
+				Header: head,
+			}
+			gotDelay := fn(0, resp)
+
+			assert.LessOrEqual(t, td.wantDelayMin, gotDelay)
+			assert.GreaterOrEqual(t, td.wantDelayMax, gotDelay)
+		})
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,0 +1,101 @@
+// Package client provides an [*net/http.Client] wrapper that automatically
+// retries failed requests when it is safe to do so.
+package client
+
+import (
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultMaxRetries                   = 5
+	defaultExponentialBackoffBase       = 1 * time.Second
+	defaultExponentialBackoffCap        = 30 * time.Second
+	defaultExponentialBackoffMultiplier = 2
+)
+
+type requestDoer interface {
+	// Do performs an HTTP request.
+	// May not strictly adhere to RoundTripper/Client semantics.
+	Do(*http.Request) (*http.Response, error)
+}
+
+// Client is a wrapper for http.Client that can retry
+// on transient errors, with respect to request idempotency.
+// Safe for concurrent use, just like [net/http.Client].
+type Client struct {
+	maxRetries int
+	backoff    BackoffFunc
+	debugDst   io.Writer
+
+	requestDoer
+	rootClient *http.Client
+}
+
+// Option is a client configuration option.
+type Option func(*Client)
+
+// WithMaxRetries sets a custom amount of maximum retries.
+func WithMaxRetries(n int) Option {
+	return func(c *Client) {
+		c.maxRetries = n
+	}
+}
+
+// WithBackoff sets a custom backoff generation function.
+func WithBackoff(b BackoffFunc) Option {
+	return func(c *Client) {
+		c.backoff = b
+	}
+}
+
+// WithHTTPClient sets a custom base HTTP client.
+func WithHTTPClient(c *http.Client) Option {
+	return func(cc *Client) {
+		cc.rootClient = c
+	}
+}
+
+// WithDebug enables debug mode, which dumps logs to w.
+// No logs will be dumped if w is nil.
+func WithDebug(w io.Writer) Option {
+	return func(c *Client) {
+		c.debugDst = w
+	}
+}
+
+// New creates a new client.
+func New(opts ...Option) *Client {
+	client := Client{
+		maxRetries: defaultMaxRetries,
+		backoff: RateLimitedExponentialBackoff(
+			ExponentialBackoffConfig{
+				Base:       defaultExponentialBackoffBase,
+				Cap:        defaultExponentialBackoffCap,
+				Multiplier: defaultExponentialBackoffMultiplier,
+			},
+		),
+		rootClient: http.DefaultClient,
+	}
+
+	for _, opt := range opts {
+		opt(&client)
+	}
+
+	var c requestDoer = client.rootClient
+	if client.debugDst != nil {
+		c = &debugger{
+			wrapped: client.rootClient,
+			dst:     client.debugDst,
+		}
+	}
+
+	client.requestDoer = &retrier{
+		wrapped:    c,
+		maxRetries: client.maxRetries,
+		backoff:    client.backoff,
+	}
+
+	return &client
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,50 @@
+package client_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cherryservers/cherrygo/v3/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testBackoff() client.BackoffFunc {
+	return func(_ int, _ *http.Response) time.Duration {
+		return time.Nanosecond
+	}
+}
+
+func TestClientOneShotSuccess(t *testing.T) {
+	client := client.New()
+	count := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintln(w, "test")
+		count++
+	}))
+	defer ts.Close()
+
+	spy := spyReadCloser{
+		real: io.NopCloser(strings.NewReader("test")),
+	}
+
+	req, err := http.NewRequest("GET", ts.URL, &spy)
+	require.NoError(t, err)
+
+	resp, doErr := client.Do(req)
+	body, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+
+	assert.NoError(t, doErr)
+	assert.NoError(t, readErr)
+	assert.NoError(t, closeErr)
+	assert.Equal(t, "test\n", string(body))
+	assert.Equal(t, 1, count)
+	assert.Equal(t, 1, spy.closes)
+}

--- a/internal/client/debug.go
+++ b/internal/client/debug.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"sync"
+)
+
+type debugger struct {
+	wrapped requestDoer
+	dst     io.Writer
+	l       *log.Logger
+
+	once sync.Once
+}
+
+func (d *debugger) Do(req *http.Request) (*http.Response, error) {
+	d.once.Do(func() {
+		d.l = log.New(d.dst, "cherrygo ", log.Default().Flags())
+	})
+
+	// Mask token.
+	auth := req.Header.Get("Authorization")
+	if auth != "" {
+		req.Header.Set("Authorization", "***")
+	}
+
+	d.l.Printf("\nAPI Endpoint: %v\n", req.URL)
+
+	dump, err := httputil.DumpRequestOut(req, true)
+	if err != nil {
+		return nil, err
+	}
+
+	d.l.Printf("\n+++++++++++++REQUEST+++++++++++++\n%s\n+++++++++++++++++++++++++++++++++", string(dump))
+
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+
+	resp, err := d.wrapped.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	dump, err = httputil.DumpResponse(resp, true)
+	if err != nil {
+		// RoundTrip must always return err=nil if it obtained a response.
+		dump = fmt.Appendf(nil, "failed to dump response: %v", err)
+	}
+
+	d.l.Printf("\n+++++++++++++RESPONSE+++++++++++++\n%s\n+++++++++++++++++++++++++++++++++", string(dump))
+	return resp, nil
+}

--- a/internal/client/debug_test.go
+++ b/internal/client/debug_test.go
@@ -1,0 +1,42 @@
+package client_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cherryservers/cherrygo/v3/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebug(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := fmt.Fprintf(w, `{"id": 1}`)
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	buf := &bytes.Buffer{}
+
+	client := client.New(client.WithDebug(buf))
+	req, err := http.NewRequest("GET", ts.URL, strings.NewReader("test"))
+	require.NoError(t, err)
+
+	req.Header.Add("Authorization", "SECRET")
+
+	_, err = client.Do(req)
+	require.NoError(t, err)
+
+	got, err := io.ReadAll(buf)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(got), "REQUEST")
+	assert.Contains(t, string(got), "RESPONSE")
+	assert.Contains(t, string(got), "***")
+	assert.NotContains(t, string(got), "SECRET")
+}

--- a/internal/client/retry.go
+++ b/internal/client/retry.go
@@ -1,0 +1,151 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"slices"
+	"time"
+)
+
+const bodyReadLimit = 4096
+
+type retrier struct {
+	wrapped    requestDoer
+	maxRetries int
+	backoff    BackoffFunc
+}
+
+// Do executes requests, retrying unsuccessful ones, when it safe to do so.
+//
+// Requests are passed to the wrapped [requestDoer], which is expected to act like a
+// [net/http.Client]. If the response status code indicates success or is unsafe to
+// retry, returns that response with a nil error. If the request context
+// expires or the retry attempt limit is reached, the response will be nil and
+// an error will be returned.
+func (r *retrier) Do(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+	var lastErr error
+
+	// The original request is discarded, make sure its body is closed.
+	defer func() {
+		if req.Body != nil {
+			_ = req.Body.Close()
+		}
+	}()
+
+	for attempts := 0; attempts < r.maxRetries+1; attempts++ {
+		clone, err := cloneRequest(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to clone request: %w", err)
+		}
+
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		resp, err := r.wrapped.Do(clone)
+		if err != nil {
+			if !isTransient(err) || !isIdempotent(clone.Method) {
+				return nil, err
+			}
+			lastErr = err
+		} else {
+			if isSuccessful(resp.StatusCode) || !safeToRetry(resp.StatusCode, clone.Method) {
+				return resp, nil
+			}
+			lastErr = fmt.Errorf("bad status: %q", resp.Status)
+
+			// Try to drain and close the body, so the connection is freed.
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, bodyReadLimit))
+			_ = resp.Body.Close()
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(r.backoff(attempts, resp)):
+		}
+	}
+
+	return nil, fmt.Errorf("max retries %d exceeded, last attempt: %w", r.maxRetries, lastErr)
+}
+
+func cloneRequest(ctx context.Context, req *http.Request) (*http.Request, error) {
+	c := req.Clone(ctx)
+	if req.Body == nil {
+		return c, nil
+	}
+
+	if req.GetBody == nil {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
+		_ = req.Body.Close()
+
+		req.GetBody = func() (io.ReadCloser, error) {
+			buf := bytes.NewBuffer(body)
+			return io.NopCloser(buf), nil
+		}
+
+		req.Body, err = req.GetBody()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get request body: %w", err)
+		}
+	}
+
+	var err error
+
+	c.Body, err = req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func isTransient(err error) bool {
+	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) {
+			if netErr.Timeout() {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func isSuccessful(status int) bool {
+	return status >= 200 && status < 300
+}
+
+func isIdempotent(method string) bool {
+	return method != http.MethodConnect &&
+		method != http.MethodPost &&
+		method != http.MethodPatch
+}
+
+func safeToRetry(status int, method string) bool {
+	idempotentRetryable := []int{
+		http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	}
+	nonIdempotentRetryable := []int{
+		http.StatusServiceUnavailable,
+		http.StatusTooManyRequests,
+	}
+
+	if isIdempotent(method) {
+		return slices.Contains(idempotentRetryable, status)
+	}
+	return slices.Contains(nonIdempotentRetryable, status)
+}

--- a/internal/client/retry_test.go
+++ b/internal/client/retry_test.go
@@ -1,0 +1,296 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cherryservers/cherrygo/v3/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupSpies(t *testing.T) (spyReadCloser, spyRoundTripper) {
+	t.Helper()
+
+	reqSpy := spyReadCloser{
+		real: io.NopCloser(strings.NewReader("test")),
+	}
+
+	respSpy := spyRoundTripper{
+		real: http.DefaultTransport,
+	}
+
+	return reqSpy, respSpy
+}
+
+type retryTestCase struct {
+	title          string
+	maxRetries     int
+	method         string
+	status         int
+	fn             http.HandlerFunc
+	reqCtx         context.Context
+	backoffFn      client.BackoffFunc
+	wantCalls      int
+	wantErr        bool
+	wantRespDrains int
+	wantBody       string
+}
+
+func testRetry(t *testing.T, tc retryTestCase) {
+	t.Run(tc.title, func(t *testing.T) {
+		reqSpy, respSpy := setupSpies(t)
+
+		httpClient := http.Client{
+			Transport: &respSpy,
+		}
+
+		client := client.New(
+			client.WithBackoff(tc.backoffFn),
+			client.WithHTTPClient(&httpClient),
+			client.WithMaxRetries(tc.maxRetries),
+		)
+		calls := 0
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tc.fn(w, r)
+			calls++
+		}))
+		defer ts.Close()
+
+		req, err := http.NewRequestWithContext(tc.reqCtx, tc.method, ts.URL, &reqSpy)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+
+		assert.Equal(t, tc.wantRespDrains, respSpy.rc.closes, "Unexpected number of response drains.")
+		assert.Equal(t, tc.wantRespDrains, respSpy.rc.reads, "Unexpected number of response drains.")
+		assert.Equal(t, 1, reqSpy.closes, "The original request body should be closed exactly once.")
+		assert.Equal(t, tc.wantCalls, calls, "Incorrect number HTTP server requests.")
+
+		if tc.wantErr {
+			assert.Error(t, err)
+			assert.Nil(t, resp)
+		} else {
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			body, readErr := io.ReadAll(resp.Body)
+			closeErr := resp.Body.Close()
+
+			assert.NoError(t, readErr)
+			assert.NoError(t, closeErr)
+			assert.Equal(t, tc.wantBody, string(body))
+		}
+	})
+}
+
+func TestRetry(t *testing.T) {
+	retryable := map[string][]int{
+		"GET":    {408, 429, 502, 503, 504},
+		"DELETE": {408, 429, 502, 503, 504},
+		"PUT":    {408, 429, 502, 503, 504},
+		"POST":   {429, 503},
+		"PATCH":  {429, 503},
+	}
+
+	for method, statuses := range retryable {
+		for _, status := range statuses {
+			calls := 0
+			testRetry(t, retryTestCase{
+				title:      fmt.Sprintf("succeed on retry: method %q, status %d", method, status),
+				maxRetries: 5,
+				method:     method,
+				status:     status,
+				fn: func(w http.ResponseWriter, _ *http.Request) {
+					if calls == 0 {
+						w.WriteHeader(status)
+						_, _ = fmt.Fprint(w, "error")
+					} else {
+						_, _ = fmt.Fprint(w, "test")
+					}
+					calls++
+				},
+				reqCtx:         t.Context(),
+				backoffFn:      testBackoff(),
+				wantCalls:      2,
+				wantErr:        false,
+				wantRespDrains: 1,
+				wantBody:       "test",
+			})
+			testRetry(t, retryTestCase{
+				title:      fmt.Sprintf("exceed max retries: method %q, status %d", method, status),
+				maxRetries: 5,
+				method:     method,
+				status:     status,
+				fn: func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(status)
+					_, _ = fmt.Fprint(w, "error")
+				},
+				reqCtx:         t.Context(),
+				backoffFn:      testBackoff(),
+				wantCalls:      6,
+				wantErr:        true,
+				wantRespDrains: 6,
+				wantBody:       "error",
+			})
+		}
+	}
+
+	unRetryable := map[string][]int{
+		"POST":  {408, 502, 504},
+		"PATCH": {408, 502, 504},
+	}
+
+	for method, statuses := range unRetryable {
+		for _, status := range statuses {
+			calls := 0
+			testRetry(t, retryTestCase{
+				title:      fmt.Sprintf("don't retry: method %q, status %d", method, status),
+				maxRetries: 5,
+				method:     method,
+				status:     status,
+				reqCtx:     t.Context(),
+				backoffFn:  testBackoff(),
+				fn: func(w http.ResponseWriter, _ *http.Request) {
+					if calls == 0 {
+						w.WriteHeader(status)
+						_, _ = fmt.Fprint(w, "error")
+					} else {
+						_, _ = fmt.Fprint(w, "test")
+					}
+					calls++
+				},
+				wantCalls:      1,
+				wantErr:        false,
+				wantRespDrains: 0,
+				wantBody:       "error",
+			})
+		}
+	}
+}
+
+type errorSpyRoundTripper struct {
+	err   error
+	calls int
+}
+
+func (e *errorSpyRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	e.calls++
+	return nil, e.err
+}
+
+type fakeNetError struct {
+	transient bool
+}
+
+func (e fakeNetError) Error() string {
+	return "test net error"
+}
+
+func (e fakeNetError) Temporary() bool {
+	return e.transient
+}
+
+func (e fakeNetError) Timeout() bool {
+	return e.transient
+}
+
+var _ net.Error = (*fakeNetError)(nil)
+
+func TestRetryNetworkError(t *testing.T) {
+	cases := []struct {
+		transient bool
+		wantCalls int
+		title     string
+	}{
+		{
+			title:     "don't retry non-transient net error",
+			transient: false,
+			wantCalls: 1,
+		},
+		{
+			title:     "retry transient net error",
+			transient: true,
+			wantCalls: 6,
+		},
+	}
+
+	for _, td := range cases {
+		t.Run(td.title, func(t *testing.T) {
+			reqSpy := spyReadCloser{
+				real: io.NopCloser(strings.NewReader("test")),
+			}
+
+			fakeErr := fakeNetError{
+				transient: td.transient,
+			}
+
+			rtSpy := errorSpyRoundTripper{
+				err: fakeErr,
+			}
+
+			httpClient := http.Client{
+				Transport: &rtSpy,
+			}
+
+			client := client.New(
+				client.WithBackoff(testBackoff()),
+				client.WithHTTPClient(&httpClient),
+				client.WithMaxRetries(5),
+			)
+
+			req, err := http.NewRequest("GET", "fake-url", &reqSpy)
+			require.NoError(t, err)
+
+			resp, err := client.Do(req)
+
+			assert.Error(t, err)
+			assert.Nil(t, resp)
+			assert.Equal(t, 1, reqSpy.closes, "The original request body should be closed exactly once.")
+			assert.Equal(t, td.wantCalls, rtSpy.calls)
+		})
+	}
+}
+
+func TestRetryContextCancellation(t *testing.T) {
+	calls := 0
+	reqCtx, cancel := context.WithCancel(t.Context())
+
+	var ctxCancelBackoff client.BackoffFunc = func(attempts int, _ *http.Response) time.Duration {
+		if attempts < 2 {
+			return time.Nanosecond
+		}
+		cancel()
+		return time.Second
+	}
+
+	testRetry(t, retryTestCase{
+		title:      "stop on request context cancellation",
+		maxRetries: 5,
+		method:     "GET",
+		status:     429,
+		fn: func(w http.ResponseWriter, _ *http.Request) {
+			if calls < 3 {
+				w.WriteHeader(429)
+				_, _ = fmt.Fprint(w, "error")
+			} else {
+				_, _ = fmt.Fprint(w, "test")
+			}
+			calls++
+		},
+		reqCtx:         reqCtx,
+		backoffFn:      ctxCancelBackoff,
+		wantCalls:      3,
+		wantErr:        true,
+		wantRespDrains: 3,
+		wantBody:       "",
+	})
+}

--- a/internal/client/spy_test.go
+++ b/internal/client/spy_test.go
@@ -1,0 +1,37 @@
+package client_test
+
+import (
+	"io"
+	"net/http"
+)
+
+type spyReadCloser struct {
+	closes int
+	reads  int
+	real   io.ReadCloser
+}
+
+func (s *spyReadCloser) Read(p []byte) (n int, err error) {
+	s.reads++
+	return s.real.Read(p)
+}
+
+func (s *spyReadCloser) Close() error {
+	s.closes++
+	return s.real.Close()
+}
+
+type spyRoundTripper struct {
+	rc   spyReadCloser
+	real http.RoundTripper
+}
+
+func (rt *spyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.real.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	rt.rc.real = resp.Body
+	resp.Body = &rt.rc
+	return resp, err
+}

--- a/ipaddresses_test.go
+++ b/ipaddresses_test.go
@@ -67,7 +67,7 @@ func TestIpAddresses_List(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	ips, _, err := client.IPAddresses.List(projectID, nil)
+	ips, _, err := testClient.IPAddresses.List(projectID, nil)
 
 	if err != nil {
 		t.Errorf("IPAddresses.List returned %+v", err)
@@ -160,7 +160,7 @@ func TestIpAddress_Get(t *testing.T) {
 		 }`)
 	})
 
-	ip, _, err := client.IPAddresses.Get(ipUID, nil)
+	ip, _, err := testClient.IPAddresses.Get(ipUID, nil)
 	if err != nil {
 		t.Errorf("IPAddress.List returned %+v", err)
 	}
@@ -241,7 +241,7 @@ func TestIpAddress_Create(t *testing.T) {
 		Tags:      &tags,
 	}
 
-	ipAddress, _, err := client.IPAddresses.Create(projectID, &ipCreate)
+	ipAddress, _, err := testClient.IPAddresses.Create(projectID, &ipCreate)
 	if err != nil {
 		t.Errorf("IPAddress.Create returned %+v", err)
 	}
@@ -294,7 +294,7 @@ func TestIpAddress_Update(t *testing.T) {
 		Tags:      &tags,
 	}
 
-	ipAddress, _, err := client.IPAddresses.Update(ipId, &ipUpdate)
+	ipAddress, _, err := testClient.IPAddresses.Update(ipId, &ipUpdate)
 	if err != nil {
 		t.Errorf("IPAddress.Update returned %+v", err)
 	}
@@ -318,7 +318,7 @@ func TestIpAddress_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := client.IPAddresses.Remove(ipId)
+	_, err := testClient.IPAddresses.Remove(ipId)
 
 	if err != nil {
 		t.Errorf("IPAddress.Remove returned %+v", err)

--- a/plans_test.go
+++ b/plans_test.go
@@ -18,7 +18,7 @@ func TestPlans_List(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	plans, _, err := client.Plans.List(teamID, nil)
+	plans, _, err := testClient.Plans.List(teamID, nil)
 	if err != nil {
 		t.Errorf("Plans.List returned %+v", err)
 	}

--- a/projects_test.go
+++ b/projects_test.go
@@ -43,7 +43,7 @@ func TestProjects_List(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	projects, _, err := client.Projects.List(teamID, nil)
+	projects, _, err := testClient.Projects.List(teamID, nil)
 
 	if err != nil {
 		t.Errorf("Projects.List returned %+v", err)
@@ -81,7 +81,7 @@ func TestProject_Get(t *testing.T) {
 		}`)
 	})
 
-	project, _, err := client.Projects.Get(projectID, nil)
+	project, _, err := testClient.Projects.Get(projectID, nil)
 	if err != nil {
 		t.Errorf("Project.List returned %+v", err)
 	}
@@ -131,7 +131,7 @@ func TestProject_Create(t *testing.T) {
 		Name: "My Custom Project",
 	}
 
-	project, _, err := client.Projects.Create(teamID, &projectCreate)
+	project, _, err := testClient.Projects.Create(teamID, &projectCreate)
 	if err != nil {
 		t.Errorf("Project.Create returned %+v", err)
 	}
@@ -174,7 +174,7 @@ func TestProject_Update(t *testing.T) {
 		Bgp:  &bgp,
 	}
 
-	_, _, err := client.Projects.Update(projectID, &projectUpdate)
+	_, _, err := testClient.Projects.Update(projectID, &projectUpdate)
 	if err != nil {
 		t.Errorf("Project.Update returned %+v", err)
 	}
@@ -192,7 +192,7 @@ func TestProject_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := client.Projects.Delete(projectID)
+	_, err := testClient.Projects.Delete(projectID)
 
 	if err != nil {
 		t.Errorf("Project.Delete returned %+v", err)
@@ -224,7 +224,7 @@ func TestProjectSSHKeys_List(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	sshKeys, _, err := client.Projects.ListSSHKeys(123, nil)
+	sshKeys, _, err := testClient.Projects.ListSSHKeys(123, nil)
 	if err != nil {
 		t.Errorf("Projects.ListSSHKeys returned %+v", err)
 	}

--- a/regions_test.go
+++ b/regions_test.go
@@ -48,7 +48,7 @@ func TestRegions_List(t *testing.T) {
 		]`)
 	})
 
-	regions, _, err := client.Regions.List(nil)
+	regions, _, err := testClient.Regions.List(nil)
 	if err != nil {
 		t.Errorf("Regions.List returned %+v", err)
 	}
@@ -81,7 +81,7 @@ func TestRegion_Get(t *testing.T) {
 		}`)
 	})
 
-	region, _, err := client.Regions.Get("eu_nord_1", nil)
+	region, _, err := testClient.Regions.Get("eu_nord_1", nil)
 	if err != nil {
 		t.Errorf("Regions.Get returned %+v", err)
 	}

--- a/servers_test.go
+++ b/servers_test.go
@@ -47,7 +47,7 @@ func TestServer_Get(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	server, _, err := client.Servers.Get(383531, nil)
+	server, _, err := testClient.Servers.Get(383531, nil)
 	if err != nil {
 		t.Errorf("Servers.Get returned %+v", err)
 	}
@@ -74,7 +74,7 @@ func TestServer_PowerState(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	power, _, err := client.Servers.PowerState(383531)
+	power, _, err := testClient.Servers.PowerState(383531)
 	if err != nil {
 		t.Errorf("Server.PowerState returned %+v", err)
 	}
@@ -149,7 +149,7 @@ func TestServer_Create(t *testing.T) {
 		Tags:        &tags,
 	}
 
-	server, _, err := client.Servers.Create(&serverCreate)
+	server, _, err := testClient.Servers.Create(&serverCreate)
 
 	if err != nil {
 		t.Errorf("Server.Create returned %+v", err)
@@ -172,7 +172,7 @@ func TestServer_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, _, err := client.Servers.Delete(383531)
+	_, _, err := testClient.Servers.Delete(383531)
 
 	if err != nil {
 		t.Errorf("Server.Delete returned %+v", err)
@@ -209,7 +209,7 @@ func TestServer_PowerOn(t *testing.T) {
 		fmt.Fprint(writer, string(jsonBytes))
 	})
 
-	_, _, err := client.Servers.PowerOn(383531)
+	_, _, err := testClient.Servers.PowerOn(383531)
 
 	if err != nil {
 		t.Errorf("Server.PowerOn returned %+v", err)
@@ -246,7 +246,7 @@ func TestServer_PowerOff(t *testing.T) {
 		fmt.Fprint(writer, string(jsonBytes))
 	})
 
-	_, _, err := client.Servers.PowerOff(383531)
+	_, _, err := testClient.Servers.PowerOff(383531)
 
 	if err != nil {
 		t.Errorf("Server.PowerOff returned %+v", err)
@@ -283,7 +283,7 @@ func TestServer_Reboot(t *testing.T) {
 		fmt.Fprint(writer, string(jsonBytes))
 	})
 
-	_, _, err := client.Servers.Reboot(383531)
+	_, _, err := testClient.Servers.Reboot(383531)
 
 	if err != nil {
 		t.Errorf("Server.Reboot returned %+v", err)
@@ -323,7 +323,7 @@ func TestServer_EnterRescueMode(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	_, _, err := client.Servers.EnterRescueMode(383531, &RescueServerFields{Password: "abcdef"})
+	_, _, err := testClient.Servers.EnterRescueMode(383531, &RescueServerFields{Password: "abcdef"})
 	if err != nil {
 		t.Errorf("Server.EnterRescueMode returned %+v", err)
 	}
@@ -361,7 +361,7 @@ func TestServer_ExitRescueMode(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	_, _, err := client.Servers.ExitRescueMode(383531)
+	_, _, err := testClient.Servers.ExitRescueMode(383531)
 	if err != nil {
 		t.Errorf("Server.ExitRescueMode returned %+v", err)
 	}
@@ -396,7 +396,7 @@ func TestServersClient_ResetBMCPassword(t *testing.T) {
 		fmt.Fprint(writer, string(jsonBytes))
 	})
 
-	if _, _, err := client.Servers.ResetBMCPassword(383531); err != nil {
+	if _, _, err := testClient.Servers.ResetBMCPassword(383531); err != nil {
 		t.Errorf("Servers.ResetBMCPassword returned %+v", err)
 	}
 }
@@ -448,7 +448,7 @@ func TestServer_Update(t *testing.T) {
 		Hostname: "cherry.prod",
 	}
 
-	server, _, err := client.Servers.Update(383531, &serverUpdate)
+	server, _, err := testClient.Servers.Update(383531, &serverUpdate)
 
 	if err != nil {
 		t.Errorf("Server.Update returned %+v", err)

--- a/sshkeys_test.go
+++ b/sshkeys_test.go
@@ -31,7 +31,7 @@ func TestSSHKey_Get(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	sshKey, _, err := client.SSHKeys.Get(1, nil)
+	sshKey, _, err := testClient.SSHKeys.Get(1, nil)
 	if err != nil {
 		t.Errorf("SSHKey.List returned %+v", err)
 	}
@@ -83,7 +83,7 @@ func TestSSHKey_Create(t *testing.T) {
 		Key:   "ssh-rsa AAAAB3NzaC1yc",
 	}
 
-	_, _, err := client.SSHKeys.Create(&sshCreate)
+	_, _, err := testClient.SSHKeys.Create(&sshCreate)
 
 	if err != nil {
 		t.Errorf("SSHKey.Create returned %+v", err)
@@ -102,7 +102,7 @@ func TestSSHKey_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, _, err := client.SSHKeys.Delete(1)
+	_, _, err := testClient.SSHKeys.Delete(1)
 
 	if err != nil {
 		t.Errorf("SSHKey.Delete returned %+v", err)
@@ -148,7 +148,7 @@ func TestSSHKey_Update(t *testing.T) {
 		Key:   &key,
 	}
 
-	_, _, err := client.SSHKeys.Update(1, &sshUpdate)
+	_, _, err := testClient.SSHKeys.Update(1, &sshUpdate)
 
 	if err != nil {
 		t.Errorf("SSHKey.Update returned %+v", err)

--- a/storages_test.go
+++ b/storages_test.go
@@ -50,7 +50,7 @@ func TestStorage_Get(t *testing.T) {
 		}`)
 	})
 
-	storage, _, err := client.Storages.Get(123, nil)
+	storage, _, err := testClient.Storages.Get(123, nil)
 	if err != nil {
 		t.Errorf("Storage.List returned %+v", err)
 	}
@@ -94,7 +94,7 @@ func TestStorage_Create(t *testing.T) {
 		Region:      "EU-Nord-1",
 	}
 
-	_, _, err := client.Storages.Create(&createStorage)
+	_, _, err := testClient.Storages.Create(&createStorage)
 	if err != nil {
 		t.Errorf("Storage.List returned %+v", err)
 	}
@@ -110,7 +110,7 @@ func TestStorage_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := client.Storages.Delete(123)
+	_, err := testClient.Storages.Delete(123)
 	if err != nil {
 		t.Errorf("Storage.Delete returned %+v", err)
 	}
@@ -146,7 +146,7 @@ func TestStorage_Attach(t *testing.T) {
 		AttachTo:  1234,
 	}
 
-	_, _, err := client.Storages.Attach(&attachStorage)
+	_, _, err := testClient.Storages.Attach(&attachStorage)
 	if err != nil {
 		t.Errorf("Storage.Attach returned %+v", err)
 	}
@@ -162,7 +162,7 @@ func TestStorage_Detach(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := client.Storages.Detach(123)
+	_, err := testClient.Storages.Detach(123)
 	if err != nil {
 		t.Errorf("Storage.Detach returned %+v", err)
 	}
@@ -200,7 +200,7 @@ func TestStorage_Update(t *testing.T) {
 		Description: "volume 1",
 	}
 
-	_, _, err := client.Storages.Update(&updateStorage)
+	_, _, err := testClient.Storages.Update(&updateStorage)
 	if err != nil {
 		t.Errorf("Storage.Update returned %+v", err)
 	}

--- a/teams_test.go
+++ b/teams_test.go
@@ -16,7 +16,7 @@ func TestTeam_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := client.Teams.Delete(123)
+	_, err := testClient.Teams.Delete(123)
 	if err != nil {
 		t.Errorf("Teams.Delete returned %+v", err)
 	}

--- a/users_test.go
+++ b/users_test.go
@@ -36,7 +36,7 @@ func TestUser_Current(t *testing.T) {
 			 }`)
 	})
 
-	user, _, err := client.Users.CurrentUser(nil)
+	user, _, err := testClient.Users.CurrentUser(nil)
 	if err != nil {
 		t.Errorf("Users.CurrentUser returned %+v", err)
 	}


### PR DESCRIPTION
Add an internal client that supports automatic retrying (with exponential backoff and jitter) as well as rate limiting.

The rate limiter implementation is a bit naive, relying only on `Retry-After` headers, with no respect to concurrency, but anything more sophisticated would have to rely on allowed throughput estimations, since we currently don't return any more in-depth rate limit metadata and I'd rather avoid doing so, since we might provide that data in the future.

Based on https://github.com/cherryservers/cherrygo/pull/75, so that should be merged first.