### PR TITLE
Add context parameters to client methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,18 @@ You can view Cherry Servers API docs here: [https://api.cherryservers.com/doc](h
 
 ## Table of Contents
 
-- [Installation](#installation)
-- [Authentication](#authentication)
-- [Examples](#examples)
-  - [Get teams](#get-teams)
-  - [Get projects](#get-projects)
-  - [Get plans](#get-plans)
-  - [Get images](#get-images)
-  - [Request new server](#request-new-server)
+- [cherrygo](#cherrygo)
+  - [Table of Contents](#table-of-contents)
+  - [Installation](#installation)
+    - [Authentication](#authentication)
+    - [Examples](#examples)
+      - [Get teams](#get-teams)
+      - [Get projects](#get-projects)
+      - [Get plans](#get-plans)
+      - [Get images](#get-images)
+      - [Request new server](#request-new-server)
+  - [Debug](#debug)
+  - [License](#license)
 
 ## Installation
 
@@ -128,10 +132,6 @@ Unset the variable to stop debugging.
 ```
 unset CHERRY_DEBUG
 ```
-
-## Release process
-
-Before release, the `libraryVersion` constant in `cherrygo.go` should be set to the correct version.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ You can view Cherry Servers API docs here: [https://api.cherryservers.com/doc](h
       - [Get plans](#get-plans)
       - [Get images](#get-images)
       - [Request new server](#request-new-server)
-  - [Debug](#debug)
   - [License](#license)
 
 ## Installation
@@ -119,18 +118,6 @@ if err != nil {
 }
 
 log.Println(server.ID, server.Name, server.Hostname)
-```
-
-## Debug
-
-If you want to debug this library, set the CHERRY_DEBUG environment variable to true, which enables full API request and response logging.
-```
-export CHERRY_DEBUG="true"
-```
-
-Unset the variable to stop debugging.
-```
-unset CHERRY_DEBUG
 ```
 
 ## License

--- a/backups.go
+++ b/backups.go
@@ -1,17 +1,21 @@
 package cherrygo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
 
 const baseBackupPath = "/v1/backup-storages"
 
 type BackupsService interface {
-	ListPlans(opts *GetOptions) ([]BackupStoragePlan, *Response, error)
-	ListBackups(projectID int, opts *GetOptions) ([]BackupStorage, *Response, error)
-	Get(backupID int, opts *GetOptions) (BackupStorage, *Response, error)
-	Create(request *CreateBackup) (BackupStorage, *Response, error)
-	Update(request *UpdateBackupStorage) (BackupStorage, *Response, error)
-	UpdateBackupMethod(request *UpdateBackupMethod) ([]BackupMethod, *Response, error)
-	Delete(backupID int) (*Response, error)
+	ListPlans(ctx context.Context, opts *GetOptions) ([]BackupStoragePlan, *Response, error)
+	ListBackups(ctx context.Context, projectID int, opts *GetOptions) ([]BackupStorage, *Response, error)
+	Get(ctx context.Context, backupID int, opts *GetOptions) (BackupStorage, *Response, error)
+	Create(ctx context.Context, request *CreateBackup) (BackupStorage, *Response, error)
+	Update(ctx context.Context, request *UpdateBackupStorage) (BackupStorage, *Response, error)
+	UpdateBackupMethod(ctx context.Context, request *UpdateBackupMethod) ([]BackupMethod, *Response, error)
+	Delete(ctx context.Context, backupID int) (*Response, error)
 }
 
 type BackupsClient struct {
@@ -91,11 +95,16 @@ type UpdateBackupMethod struct {
 	Whitelist        []string `json:"whitelist"`
 }
 
-func (s *BackupsClient) ListPlans(opts *GetOptions) ([]BackupStoragePlan, *Response, error) {
-	path := opts.WithQuery(fmt.Sprintf("/v1/backup-storage-plans"))
-
+func (s *BackupsClient) ListPlans(ctx context.Context, opts *GetOptions) ([]BackupStoragePlan, *Response, error) {
 	var trans []BackupStoragePlan
-	resp, err := s.client.MakeRequest("GET", path, nil, &trans)
+
+	path := opts.WithQuery(fmt.Sprintf("/v1/backup-storage-plans"))
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -103,11 +112,16 @@ func (s *BackupsClient) ListPlans(opts *GetOptions) ([]BackupStoragePlan, *Respo
 	return trans, resp, err
 }
 
-func (s *BackupsClient) ListBackups(projectID int, opts *GetOptions) ([]BackupStorage, *Response, error) {
+func (s *BackupsClient) ListBackups(ctx context.Context, projectID int, opts *GetOptions) ([]BackupStorage, *Response, error) {
 	var trans []BackupStorage
 
 	path := opts.WithQuery(fmt.Sprintf("/v1/projects/%d/backup-storages", projectID))
-	resp, err := s.client.MakeRequest("GET", path, nil, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -115,11 +129,16 @@ func (s *BackupsClient) ListBackups(projectID int, opts *GetOptions) ([]BackupSt
 	return trans, resp, err
 }
 
-func (s *BackupsClient) Get(backupID int, opts *GetOptions) (BackupStorage, *Response, error) {
+func (s *BackupsClient) Get(ctx context.Context, backupID int, opts *GetOptions) (BackupStorage, *Response, error) {
 	var trans BackupStorage
 
 	path := opts.WithQuery(fmt.Sprintf("%s/%d", baseBackupPath, backupID))
-	resp, err := s.client.MakeRequest("GET", path, nil, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return BackupStorage{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -127,11 +146,17 @@ func (s *BackupsClient) Get(backupID int, opts *GetOptions) (BackupStorage, *Res
 	return trans, resp, err
 }
 
-func (s *BackupsClient) Create(request *CreateBackup) (BackupStorage, *Response, error) {
+func (s *BackupsClient) Create(ctx context.Context, request *CreateBackup) (BackupStorage, *Response, error) {
 	var trans BackupStorage
 
 	path := fmt.Sprintf("/v1/servers/%d/backup-storages", request.ServerID)
-	resp, err := s.client.MakeRequest("POST", path, request, &trans)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return BackupStorage{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -139,12 +164,17 @@ func (s *BackupsClient) Create(request *CreateBackup) (BackupStorage, *Response,
 	return trans, resp, err
 }
 
-func (s *BackupsClient) Update(request *UpdateBackupStorage) (BackupStorage, *Response, error) {
+func (s *BackupsClient) Update(ctx context.Context, request *UpdateBackupStorage) (BackupStorage, *Response, error) {
 	var trans BackupStorage
 
 	path := fmt.Sprintf("%s/%d", baseBackupPath, request.BackupStorageID)
 
-	resp, err := s.client.MakeRequest("PUT", path, request, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodPut, path, request)
+	if err != nil {
+		return BackupStorage{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -152,11 +182,16 @@ func (s *BackupsClient) Update(request *UpdateBackupStorage) (BackupStorage, *Re
 	return trans, resp, err
 }
 
-func (s *BackupsClient) UpdateBackupMethod(request *UpdateBackupMethod) ([]BackupMethod, *Response, error) {
+func (s *BackupsClient) UpdateBackupMethod(ctx context.Context, request *UpdateBackupMethod) ([]BackupMethod, *Response, error) {
 	var trans []BackupMethod
 
 	path := fmt.Sprintf("%s/%d/methods/%s", baseBackupPath, request.BackupStorageID, request.BackupMethodName)
-	resp, err := s.client.MakeRequest("PATCH", path, request, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodPatch, path, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -164,9 +199,14 @@ func (s *BackupsClient) UpdateBackupMethod(request *UpdateBackupMethod) ([]Backu
 	return trans, resp, err
 }
 
-func (s *BackupsClient) Delete(backupID int) (*Response, error) {
+func (s *BackupsClient) Delete(ctx context.Context, backupID int) (*Response, error) {
 	path := fmt.Sprintf("%s/%d", baseBackupPath, backupID)
-	resp, err := s.client.MakeRequest("DELETE", path, nil, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}

--- a/backups_test.go
+++ b/backups_test.go
@@ -36,7 +36,7 @@ func TestBackupStorage_Get(t *testing.T) {
 		}`)
 	})
 
-	backup, _, err := testClient.Backups.Get(123, nil)
+	backup, _, err := testClient.Backups.Get(t.Context(), 123, nil)
 	if err != nil {
 		t.Errorf("Backups.Get returned %+v", err)
 	}
@@ -63,8 +63,7 @@ func TestBackupStorage_ListBackups(t *testing.T) {
 		]`)
 	})
 
-	backups, _, err := testClient.Backups.ListBackups(projectID, nil)
-
+	backups, _, err := testClient.Backups.ListBackups(t.Context(), projectID, nil)
 	if err != nil {
 		t.Errorf("Backups.ListBackups returned %+v", err)
 	}
@@ -101,8 +100,7 @@ func TestBackupStorage_ListPlans(t *testing.T) {
 		]`)
 	})
 
-	backupPlans, _, err := testClient.Backups.ListPlans(nil)
-
+	backupPlans, _, err := testClient.Backups.ListPlans(t.Context(), nil)
 	if err != nil {
 		t.Errorf("Backups.ListPlans returned %+v", err)
 	}
@@ -147,7 +145,7 @@ func TestBackupStorage_Create(t *testing.T) {
 		SSHKey:         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6ec8eT...",
 	}
 
-	_, _, err := testClient.Backups.Create(&createBackup)
+	_, _, err := testClient.Backups.Create(t.Context(), &createBackup)
 	if err != nil {
 		t.Errorf("Backup.Create returned %+v", err)
 	}
@@ -185,7 +183,7 @@ func TestBackupStorage_Update(t *testing.T) {
 		Password:        "abc123",
 	}
 
-	_, _, err := testClient.Backups.Update(&updateBackupStorage)
+	_, _, err := testClient.Backups.Update(t.Context(), &updateBackupStorage)
 	if err != nil {
 		t.Errorf("Backups.Update returned %+v", err)
 	}
@@ -233,7 +231,7 @@ func TestBackupStorage_UpdateMethod(t *testing.T) {
 		Whitelist:        []string{"1.1.1.1", "2.2.2.2"},
 	}
 
-	_, _, err := testClient.Backups.UpdateBackupMethod(&updateBackupMethod)
+	_, _, err := testClient.Backups.UpdateBackupMethod(t.Context(), &updateBackupMethod)
 	if err != nil {
 		t.Errorf("Backups.UpdateBackupMethod returned %+v", err)
 	}
@@ -249,7 +247,7 @@ func TestBackupStorage_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := testClient.Backups.Delete(123)
+	_, err := testClient.Backups.Delete(t.Context(), 123)
 	if err != nil {
 		t.Errorf("Backups.Delete returned %+v", err)
 	}

--- a/backups_test.go
+++ b/backups_test.go
@@ -36,7 +36,7 @@ func TestBackupStorage_Get(t *testing.T) {
 		}`)
 	})
 
-	backup, _, err := client.Backups.Get(123, nil)
+	backup, _, err := testClient.Backups.Get(123, nil)
 	if err != nil {
 		t.Errorf("Backups.Get returned %+v", err)
 	}
@@ -63,7 +63,7 @@ func TestBackupStorage_ListBackups(t *testing.T) {
 		]`)
 	})
 
-	backups, _, err := client.Backups.ListBackups(projectID, nil)
+	backups, _, err := testClient.Backups.ListBackups(projectID, nil)
 
 	if err != nil {
 		t.Errorf("Backups.ListBackups returned %+v", err)
@@ -101,7 +101,7 @@ func TestBackupStorage_ListPlans(t *testing.T) {
 		]`)
 	})
 
-	backupPlans, _, err := client.Backups.ListPlans(nil)
+	backupPlans, _, err := testClient.Backups.ListPlans(nil)
 
 	if err != nil {
 		t.Errorf("Backups.ListPlans returned %+v", err)
@@ -147,7 +147,7 @@ func TestBackupStorage_Create(t *testing.T) {
 		SSHKey:         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6ec8eT...",
 	}
 
-	_, _, err := client.Backups.Create(&createBackup)
+	_, _, err := testClient.Backups.Create(&createBackup)
 	if err != nil {
 		t.Errorf("Backup.Create returned %+v", err)
 	}
@@ -185,7 +185,7 @@ func TestBackupStorage_Update(t *testing.T) {
 		Password:        "abc123",
 	}
 
-	_, _, err := client.Backups.Update(&updateBackupStorage)
+	_, _, err := testClient.Backups.Update(&updateBackupStorage)
 	if err != nil {
 		t.Errorf("Backups.Update returned %+v", err)
 	}
@@ -233,7 +233,7 @@ func TestBackupStorage_UpdateMethod(t *testing.T) {
 		Whitelist:        []string{"1.1.1.1", "2.2.2.2"},
 	}
 
-	_, _, err := client.Backups.UpdateBackupMethod(&updateBackupMethod)
+	_, _, err := testClient.Backups.UpdateBackupMethod(&updateBackupMethod)
 	if err != nil {
 		t.Errorf("Backups.UpdateBackupMethod returned %+v", err)
 	}
@@ -249,7 +249,7 @@ func TestBackupStorage_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := client.Backups.Delete(123)
+	_, err := testClient.Backups.Delete(123)
 	if err != nil {
 		t.Errorf("Backups.Delete returned %+v", err)
 	}

--- a/cherrygo.go
+++ b/cherrygo.go
@@ -8,10 +8,11 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"strconv"
+
+	"github.com/cherryservers/cherrygo/v3/internal/client"
 )
 
 const (
@@ -24,8 +25,7 @@ const (
 
 // Client returns struct for client
 type Client struct {
-	client *http.Client
-	debug  bool
+	client *client.Client
 
 	BaseURL *url.URL
 
@@ -57,13 +57,9 @@ type Meta struct {
 
 // MakeRequest makes request to API
 func (c *Client) MakeRequest(method, path string, body, v interface{}) (*Response, error) {
-
 	url, _ := url.Parse(path)
 
 	u := c.BaseURL.ResolveReference(url)
-	if c.debug {
-		fmt.Printf("\nAPI Endpoint: %v\n", u)
-	}
 
 	buf := new(bytes.Buffer)
 	if body != nil {
@@ -80,18 +76,11 @@ func (c *Client) MakeRequest(method, path string, body, v interface{}) (*Respons
 		return nil, err
 	}
 
-	req.Close = true
-
 	bearer := "Bearer " + c.AuthToken
 	req.Header.Add("Authorization", bearer)
 	req.Header.Set("User-Agent", c.UserAgent)
 	req.Header.Add("Content-Type", mediaType)
 	req.Header.Add("Accept", mediaType)
-
-	if c.debug {
-		o, _ := httputil.DumpRequestOut(req, true)
-		log.Printf("\n+++++++++++++REQUEST+++++++++++++\n%s\n+++++++++++++++++++++++++++++++++", string(o))
-	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {
@@ -102,11 +91,6 @@ func (c *Client) MakeRequest(method, path string, body, v interface{}) (*Respons
 
 	response := Response{Response: resp}
 	response.populateTotal()
-
-	if c.debug {
-		o, _ := httputil.DumpResponse(response.Response, true)
-		log.Printf("\n+++++++++++++RESPONSE+++++++++++++\n%s\n+++++++++++++++++++++++++++++++++", string(o))
-	}
 
 	if sc := response.StatusCode; sc >= 299 {
 		type ErrorResponse struct {
@@ -159,13 +143,13 @@ type options struct {
 	client    *http.Client
 	userAgent string
 	authToken string
+	debugDst  io.Writer
 }
 
 type ClientOpt func(*options) error
 
 // NewClient initialization
 func NewClient(opts ...ClientOpt) (*Client, error) {
-
 	parsedOpts := &options{
 		authToken: os.Getenv(cherryAuthTokenVar),
 		client:    &http.Client{},
@@ -186,9 +170,17 @@ func NewClient(opts ...ClientOpt) (*Client, error) {
 		return nil, err
 	}
 
-	c := &Client{client: parsedOpts.client, AuthToken: parsedOpts.authToken, BaseURL: url, UserAgent: parsedOpts.userAgent}
+	if parsedOpts.debugDst == nil && os.Getenv(cherryDebugVar) != "" {
+		parsedOpts.debugDst = os.Stderr
+	}
 
-	c.debug = os.Getenv(cherryDebugVar) != ""
+	c := &Client{
+		client:    client.New(client.WithHTTPClient(parsedOpts.client), client.WithDebug(parsedOpts.debugDst)),
+		AuthToken: parsedOpts.authToken,
+		BaseURL:   url,
+		UserAgent: parsedOpts.userAgent,
+	}
+
 	c.Teams = &TeamsClient{client: c}
 	c.Plans = &PlansClient{client: c}
 	c.Images = &ImagesClient{client: c}
@@ -223,7 +215,6 @@ func checkResponseForErrors(r *http.Response) *ErrorResponse {
 	}
 
 	return errR
-
 }
 
 // WithUserAgent set user agent when making requests
@@ -255,6 +246,16 @@ func WithHTTPClient(client *http.Client) ClientOpt {
 func WithAuthToken(authToken string) ClientOpt {
 	return func(c *options) error {
 		c.authToken = authToken
+		return nil
+	}
+}
+
+// WithDebug enables debug mode, which dumps logs to w.
+// Can also be enabled with the CHERRY_DEBUG environment variable, in which case logs
+// will be dumped to stderr.
+func WithDebug(w io.Writer) ClientOpt {
+	return func(c *options) error {
+		c.debugDst = w
 		return nil
 	}
 }

--- a/cherrygo.go
+++ b/cherrygo.go
@@ -2,10 +2,10 @@ package cherrygo
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -23,7 +23,11 @@ const (
 	cherryDebugVar     = "CHERRY_DEBUG"
 )
 
-// Client returns struct for client
+// Client is a client for the Cherry Servers RESTful API.
+//
+// Retries failed requests when it's safe to do so, e.g. status 429
+// or a network timeout with an idempotent method. Respects `Retry-After` headers
+// with fallback to exponential backoff with jitter.
 type Client struct {
 	client *client.Client
 
@@ -45,7 +49,7 @@ type Client struct {
 	Backups     BackupsService
 }
 
-// Response is the http response from api calls
+// Response is the http response from api calls.
 type Response struct {
 	*http.Response
 	Meta
@@ -55,10 +59,9 @@ type Meta struct {
 	Total int
 }
 
-// MakeRequest makes request to API
-func (c *Client) MakeRequest(method, path string, body, v interface{}) (*Response, error) {
+// NewRequest creates a request. Adds the required headers.
+func (c *Client) NewRequest(ctx context.Context, method, path string, body any) (*http.Request, error) {
 	url, _ := url.Parse(path)
-
 	u := c.BaseURL.ResolveReference(url)
 
 	buf := new(bytes.Buffer)
@@ -71,17 +74,26 @@ func (c *Client) MakeRequest(method, path string, body, v interface{}) (*Respons
 		}
 	}
 
-	req, err := http.NewRequest(method, u.String(), buf)
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), buf)
 	if err != nil {
 		return nil, err
 	}
 
 	bearer := "Bearer " + c.AuthToken
-	req.Header.Add("Authorization", bearer)
+	req.Header.Set("Authorization", bearer)
 	req.Header.Set("User-Agent", c.UserAgent)
-	req.Header.Add("Content-Type", mediaType)
-	req.Header.Add("Accept", mediaType)
+	req.Header.Set("Accept", mediaType)
+	if body != nil {
+		req.Header.Add("Content-Type", mediaType)
+	}
+	return req, nil
+}
 
+// Do executes a request.
+//
+// The response body is un-marshalled into v, so it must be a pointer
+// to a type that can hold the expected response, [io.Writer] or nil.
+func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -101,7 +113,7 @@ func (c *Client) MakeRequest(method, path string, body, v interface{}) (*Respons
 
 		var errorResponse ErrorResponse
 
-		bod, err := ioutil.ReadAll(resp.Body)
+		bod, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -116,7 +128,7 @@ func (c *Client) MakeRequest(method, path string, body, v interface{}) (*Respons
 	}
 
 	// Handling delete requests which EOF is not an error
-	if method == "DELETE" && response.StatusCode == 204 {
+	if req.Method == http.MethodDelete && response.StatusCode == http.StatusNoContent {
 		return &response, err
 	}
 
@@ -146,9 +158,10 @@ type options struct {
 	debugDst  io.Writer
 }
 
+// ClientOpt is a client configuration option.
 type ClientOpt func(*options) error
 
-// NewClient initialization
+// NewClient creates a Cherry Servers API client.
 func NewClient(opts ...ClientOpt) (*Client, error) {
 	parsedOpts := &options{
 		authToken: os.Getenv(cherryAuthTokenVar),
@@ -209,7 +222,7 @@ func checkResponseForErrors(r *http.Response) *ErrorResponse {
 	}
 
 	errR := &ErrorResponse{Response: r}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err == nil && len(data) > 0 {
 		json.Unmarshal(data, errR)
 	}

--- a/cherrygo.go
+++ b/cherrygo.go
@@ -15,11 +15,10 @@ import (
 )
 
 const (
-	libraryVersion     = "3.8.0"
 	apiURL             = "https://api.cherryservers.com/v1/"
 	cherryAuthTokenVar = "CHERRY_AUTH_TOKEN"
 	mediaType          = "application/json"
-	userAgent          = "cherry-agent-go/" + libraryVersion
+	userAgent          = "cherry-agent-go/"
 	cherryDebugVar     = "CHERRY_DEBUG"
 )
 

--- a/cherrygo_test.go
+++ b/cherrygo_test.go
@@ -1,20 +1,25 @@
 package cherrygo
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
-	mux       *http.ServeMux
-	client    *Client
-	server    *httptest.Server
-	teamID    int
-	projectID int
+	mux        *http.ServeMux
+	testClient *Client
+	server     *httptest.Server
+	teamID     int
+	projectID  int
 )
 
 var authToken = "myToken"
@@ -24,9 +29,9 @@ func setup() {
 
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
-	client, _ = NewClient()
+	testClient, _ = NewClient()
 	url, _ := url.Parse(server.URL)
-	client.BaseURL = url
+	testClient.BaseURL = url
 	teamID = 123
 	projectID = 321
 }
@@ -45,12 +50,12 @@ func TestNewClient(t *testing.T) {
 	setup()
 	defer teardown()
 
-	if client.BaseURL == nil || client.BaseURL.String() != server.URL {
-		t.Errorf("NewClient BaseURL = %v, expected %v", client.BaseURL, server.URL)
+	if testClient.BaseURL == nil || testClient.BaseURL.String() != server.URL {
+		t.Errorf("NewClient BaseURL = %v, expected %v", testClient.BaseURL, server.URL)
 	}
 
-	if client.UserAgent != userAgent {
-		t.Errorf("NewClient UserAgent = %v, expected %v", client.UserAgent, userAgent)
+	if testClient.UserAgent != userAgent {
+		t.Errorf("NewClient UserAgent = %v, expected %v", testClient.UserAgent, userAgent)
 	}
 }
 
@@ -58,7 +63,7 @@ func TestNewClientWithAuthVar(t *testing.T) {
 	c, _ := NewClient(WithAuthToken(authToken))
 
 	if c.AuthToken != authToken {
-		t.Errorf("NewClient AuthToken = %v, expected %v", client.AuthToken, authToken)
+		t.Errorf("NewClient AuthToken = %v, expected %v", testClient.AuthToken, authToken)
 	}
 }
 
@@ -75,7 +80,7 @@ func TestErrorResponse(t *testing.T) {
 		}`)
 	})
 
-	_, err := client.MakeRequest(http.MethodGet, "/", nil, nil)
+	_, err := testClient.MakeRequest(http.MethodGet, "/", nil, nil)
 
 	expectedErr := "Error response from API: Bad Request (error code: 400)"
 	if err.Error() != expectedErr {
@@ -88,7 +93,6 @@ func TestCustomUserAgent(t *testing.T) {
 
 	ua := "testing/1.0"
 	c, err := NewClient(WithUserAgent(ua))
-
 	if err != nil {
 		t.Fatalf("NewClient() unexpected error: %v", err)
 	}
@@ -97,4 +101,31 @@ func TestCustomUserAgent(t *testing.T) {
 	if got := c.UserAgent; got != expected {
 		t.Errorf("NewClient() UserAgent = %s; expected %s", got, expected)
 	}
+}
+
+func TestDebug(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/debug", func(w http.ResponseWriter, _ *http.Request) {
+		_, err := fmt.Fprintf(w, `{"id": 1}`)
+		require.NoError(t, err)
+	})
+
+	buf := &bytes.Buffer{}
+
+	c, err := NewClient(WithAuthToken("HIDDEN"), WithDebug(buf), WithURL(server.URL))
+	require.NoError(t, err)
+
+	_, err = c.MakeRequest("GET", "/debug", nil, &struct {
+		ID int `json:"id"`
+	}{})
+	require.NoError(t, err)
+
+	got, err := io.ReadAll(buf)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(got), "REQUEST")
+	assert.Contains(t, string(got), "RESPONSE")
+	assert.NotContains(t, string(got), "HIDDEN")
 }

--- a/cherrygo_test.go
+++ b/cherrygo_test.go
@@ -80,7 +80,10 @@ func TestErrorResponse(t *testing.T) {
 		}`)
 	})
 
-	_, err := testClient.MakeRequest(http.MethodGet, "/", nil, nil)
+	req, err := testClient.NewRequest(t.Context(), http.MethodGet, "/", nil)
+	require.NoError(t, err)
+
+	_, err = testClient.Do(req, nil)
 
 	expectedErr := "Error response from API: Bad Request (error code: 400)"
 	if err.Error() != expectedErr {
@@ -107,7 +110,7 @@ func TestDebug(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/debug", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/test", func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintf(w, `{"id": 1}`)
 		require.NoError(t, err)
 	})
@@ -117,7 +120,10 @@ func TestDebug(t *testing.T) {
 	c, err := NewClient(WithAuthToken("HIDDEN"), WithDebug(buf), WithURL(server.URL))
 	require.NoError(t, err)
 
-	_, err = c.MakeRequest("GET", "/debug", nil, &struct {
+	req, err := c.NewRequest(t.Context(), http.MethodGet, "/test", nil)
+	require.NoError(t, err)
+
+	_, err = c.Do(req, &struct {
 		ID int `json:"id"`
 	}{})
 	require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/cherryservers/cherrygo/v3
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.25.4
+toolchain go1.26.1

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,11 @@ module github.com/cherryservers/cherrygo/v3
 go 1.25.0
 
 toolchain go1.26.1
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/images.go
+++ b/images.go
@@ -1,7 +1,9 @@
 package cherrygo
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 )
 
 const baseImagePath = "/v1/plans"
@@ -9,7 +11,7 @@ const baseImagePath = "/v1/plans"
 // ImagesService is an interface for interfacing with the the Images endpoints of the CherryServers API
 // See: https://api.cherryservers.com/doc/#tag/Images
 type ImagesService interface {
-	List(plan string, opts *GetOptions) ([]Image, *Response, error)
+	List(ctx context.Context, plan string, opts *GetOptions) ([]Image, *Response, error)
 }
 
 type Image struct {
@@ -24,11 +26,16 @@ type ImagesClient struct {
 }
 
 // List func lists images
-func (i *ImagesClient) List(plan string, opts *GetOptions) ([]Image, *Response, error) {
+func (i *ImagesClient) List(ctx context.Context, plan string, opts *GetOptions) ([]Image, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("%s/%s/images", baseImagePath, plan))
 	var trans []Image
 
-	resp, err := i.client.MakeRequest("GET", path, nil, &trans)
+	req, err := i.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := i.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}

--- a/images_test.go
+++ b/images_test.go
@@ -56,7 +56,7 @@ func TestImages_List(t *testing.T) {
 		]`)
 	})
 
-	images, _, err := client.Images.List("e5_1620v4", nil)
+	images, _, err := testClient.Images.List("e5_1620v4", nil)
 	if err != nil {
 		t.Errorf("Images.List returned %+v", err)
 	}

--- a/images_test.go
+++ b/images_test.go
@@ -56,7 +56,7 @@ func TestImages_List(t *testing.T) {
 		]`)
 	})
 
-	images, _, err := testClient.Images.List("e5_1620v4", nil)
+	images, _, err := testClient.Images.List(t.Context(), "e5_1620v4", nil)
 	if err != nil {
 		t.Errorf("Images.List returned %+v", err)
 	}

--- a/internal/client/backoff.go
+++ b/internal/client/backoff.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// BackoffFunc generates backoff delays.
+type BackoffFunc func(attempts int, resp *http.Response) time.Duration
+
+// ExponentialBackoffConfig is the configuration for exponential backoff.
+type ExponentialBackoffConfig struct {
+	Base       time.Duration
+	Cap        time.Duration
+	Multiplier float64
+}
+
+// RateLimitedExponentialBackoff returns an backoff function
+// that prioritizes `Retry-After` headers, defaulting to exponential backoff
+// if they're not found. Adds partial jitter.
+func RateLimitedExponentialBackoff(cfg ExponentialBackoffConfig) BackoffFunc {
+	return func(attempts int, req *http.Response) time.Duration {
+		backoff, ok := parseRetryAfter(req)
+		if ok {
+			return backoff
+		}
+
+		backoffSeconds := cfg.Base.Seconds() * math.Pow(cfg.Multiplier, float64(attempts))
+		backoff = time.Second * time.Duration(backoffSeconds)
+		backoff = jitter(backoff)
+
+		return min(backoff, cfg.Cap)
+	}
+}
+
+func parseRetryAfter(req *http.Response) (time.Duration, bool) {
+	if req == nil {
+		return 0, false
+	}
+
+	// Retry-After can be an integer with seconds or an HTTP date.
+	d := req.Header.Get("Retry-After")
+
+	seconds, err := strconv.Atoi(d)
+	if err == nil {
+		return time.Duration(seconds) * time.Second, true
+	}
+
+	date, err := http.ParseTime(d)
+	if err == nil {
+		return time.Until(date), true
+	}
+
+	return 0, false
+}
+
+func jitter(base time.Duration) time.Duration {
+	return time.Duration(rand.Int64N(int64(base)/2)) + base/2
+}

--- a/internal/client/backoff_test.go
+++ b/internal/client/backoff_test.go
@@ -1,0 +1,87 @@
+package client_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cherryservers/cherrygo/v3/internal/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExponentialBackoff(t *testing.T) {
+	fn := client.RateLimitedExponentialBackoff(client.ExponentialBackoffConfig{
+		Base:       2 * time.Second,
+		Cap:        60 * time.Second,
+		Multiplier: 2,
+	})
+
+	wantDelaysMin := []time.Duration{1, 2, 4, 8, 16, 32, 60, 60}
+	wantDelaysMax := []time.Duration{2, 4, 8, 16, 32, 60, 60, 60}
+
+	gotDelays := make([]time.Duration, 0, len(wantDelaysMax))
+	gotDelaysAgain := make([]time.Duration, 0, len(wantDelaysMax))
+
+	for i := range wantDelaysMax {
+		wantDelaysMax[i] = wantDelaysMax[i] * time.Second
+		wantDelaysMin[i] = wantDelaysMin[i] * time.Second
+
+		gotDelays = append(gotDelays, fn(i, nil))
+		gotDelaysAgain = append(gotDelaysAgain, fn(i, nil))
+	}
+
+	for i := range gotDelays {
+		assert.LessOrEqual(t, wantDelaysMin[i], gotDelays[i], "Backoff delay too small.")
+		assert.GreaterOrEqual(t, wantDelaysMax[i], gotDelays[i], "Backoff delay too big.")
+
+		assert.LessOrEqual(t, wantDelaysMin[i], gotDelaysAgain[i], "Backoff delay too small.")
+		assert.GreaterOrEqual(t, wantDelaysMax[i], gotDelaysAgain[i], "Backoff delay too big.")
+	}
+	assert.NotEqual(t, gotDelays, gotDelaysAgain, "Duplicate delays generated.")
+}
+
+func TestBackoffRetryAfter(t *testing.T) {
+	now := time.Now()
+
+	cases := []struct {
+		retryAfter   string
+		wantDelayMin time.Duration
+		wantDelayMax time.Duration
+	}{
+		{
+			retryAfter:   "1",
+			wantDelayMin: 1 * time.Second,
+			wantDelayMax: 1 * time.Second,
+		},
+		{
+			retryAfter:   now.Add(time.Second * 30).UTC().Format(http.TimeFormat),
+			wantDelayMin: 25 * time.Second,
+			wantDelayMax: 30 * time.Second,
+		},
+		{
+			retryAfter:   "",
+			wantDelayMin: 1 * time.Second,
+			wantDelayMax: 2 * time.Second,
+		},
+	}
+
+	fn := client.RateLimitedExponentialBackoff(client.ExponentialBackoffConfig{
+		Base:       2 * time.Second,
+		Cap:        60 * time.Second,
+		Multiplier: 2,
+	})
+
+	for _, td := range cases {
+		t.Run(td.retryAfter, func(t *testing.T) {
+			head := make(http.Header)
+			head.Add("Retry-After", td.retryAfter)
+			resp := &http.Response{
+				Header: head,
+			}
+			gotDelay := fn(0, resp)
+
+			assert.LessOrEqual(t, td.wantDelayMin, gotDelay)
+			assert.GreaterOrEqual(t, td.wantDelayMax, gotDelay)
+		})
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,0 +1,101 @@
+// Package client provides an [*net/http.Client] wrapper that automatically
+// retries failed requests when it is safe to do so.
+package client
+
+import (
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultMaxRetries                   = 5
+	defaultExponentialBackoffBase       = 1 * time.Second
+	defaultExponentialBackoffCap        = 30 * time.Second
+	defaultExponentialBackoffMultiplier = 2
+)
+
+type requestDoer interface {
+	// Do performs an HTTP request.
+	// May not strictly adhere to RoundTripper/Client semantics.
+	Do(*http.Request) (*http.Response, error)
+}
+
+// Client is a wrapper for http.Client that can retry
+// on transient errors, with respect to request idempotency.
+// Safe for concurrent use, just like [net/http.Client].
+type Client struct {
+	maxRetries int
+	backoff    BackoffFunc
+	debugDst   io.Writer
+
+	requestDoer
+	rootClient *http.Client
+}
+
+// Option is a client configuration option.
+type Option func(*Client)
+
+// WithMaxRetries sets a custom amount of maximum retries.
+func WithMaxRetries(n int) Option {
+	return func(c *Client) {
+		c.maxRetries = n
+	}
+}
+
+// WithBackoff sets a custom backoff generation function.
+func WithBackoff(b BackoffFunc) Option {
+	return func(c *Client) {
+		c.backoff = b
+	}
+}
+
+// WithHTTPClient sets a custom base HTTP client.
+func WithHTTPClient(c *http.Client) Option {
+	return func(cc *Client) {
+		cc.rootClient = c
+	}
+}
+
+// WithDebug enables debug mode, which dumps logs to w.
+// No logs will be dumped if w is nil.
+func WithDebug(w io.Writer) Option {
+	return func(c *Client) {
+		c.debugDst = w
+	}
+}
+
+// New creates a new client.
+func New(opts ...Option) *Client {
+	client := Client{
+		maxRetries: defaultMaxRetries,
+		backoff: RateLimitedExponentialBackoff(
+			ExponentialBackoffConfig{
+				Base:       defaultExponentialBackoffBase,
+				Cap:        defaultExponentialBackoffCap,
+				Multiplier: defaultExponentialBackoffMultiplier,
+			},
+		),
+		rootClient: http.DefaultClient,
+	}
+
+	for _, opt := range opts {
+		opt(&client)
+	}
+
+	var c requestDoer = client.rootClient
+	if client.debugDst != nil {
+		c = &debugger{
+			wrapped: client.rootClient,
+			dst:     client.debugDst,
+		}
+	}
+
+	client.requestDoer = &retrier{
+		wrapped:    c,
+		maxRetries: client.maxRetries,
+		backoff:    client.backoff,
+	}
+
+	return &client
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,50 @@
+package client_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cherryservers/cherrygo/v3/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testBackoff() client.BackoffFunc {
+	return func(_ int, _ *http.Response) time.Duration {
+		return time.Nanosecond
+	}
+}
+
+func TestClientOneShotSuccess(t *testing.T) {
+	client := client.New()
+	count := 0
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintln(w, "test")
+		count++
+	}))
+	defer ts.Close()
+
+	spy := spyReadCloser{
+		real: io.NopCloser(strings.NewReader("test")),
+	}
+
+	req, err := http.NewRequest("GET", ts.URL, &spy)
+	require.NoError(t, err)
+
+	resp, doErr := client.Do(req)
+	body, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+
+	assert.NoError(t, doErr)
+	assert.NoError(t, readErr)
+	assert.NoError(t, closeErr)
+	assert.Equal(t, "test\n", string(body))
+	assert.Equal(t, 1, count)
+	assert.Equal(t, 1, spy.closes)
+}

--- a/internal/client/debug.go
+++ b/internal/client/debug.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"sync"
+)
+
+type debugger struct {
+	wrapped requestDoer
+	dst     io.Writer
+	l       *log.Logger
+
+	once sync.Once
+}
+
+func (d *debugger) Do(req *http.Request) (*http.Response, error) {
+	d.once.Do(func() {
+		d.l = log.New(d.dst, "cherrygo ", log.Default().Flags())
+	})
+
+	// Mask token.
+	auth := req.Header.Get("Authorization")
+	if auth != "" {
+		req.Header.Set("Authorization", "***")
+	}
+
+	d.l.Printf("\nAPI Endpoint: %v\n", req.URL)
+
+	dump, err := httputil.DumpRequestOut(req, true)
+	if err != nil {
+		return nil, err
+	}
+
+	d.l.Printf("\n+++++++++++++REQUEST+++++++++++++\n%s\n+++++++++++++++++++++++++++++++++", string(dump))
+
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+
+	resp, err := d.wrapped.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	dump, err = httputil.DumpResponse(resp, true)
+	if err != nil {
+		// RoundTrip must always return err=nil if it obtained a response.
+		dump = fmt.Appendf(nil, "failed to dump response: %v", err)
+	}
+
+	d.l.Printf("\n+++++++++++++RESPONSE+++++++++++++\n%s\n+++++++++++++++++++++++++++++++++", string(dump))
+	return resp, nil
+}

--- a/internal/client/debug_test.go
+++ b/internal/client/debug_test.go
@@ -1,0 +1,42 @@
+package client_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cherryservers/cherrygo/v3/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebug(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := fmt.Fprintf(w, `{"id": 1}`)
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	buf := &bytes.Buffer{}
+
+	client := client.New(client.WithDebug(buf))
+	req, err := http.NewRequest("GET", ts.URL, strings.NewReader("test"))
+	require.NoError(t, err)
+
+	req.Header.Add("Authorization", "SECRET")
+
+	_, err = client.Do(req)
+	require.NoError(t, err)
+
+	got, err := io.ReadAll(buf)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(got), "REQUEST")
+	assert.Contains(t, string(got), "RESPONSE")
+	assert.Contains(t, string(got), "***")
+	assert.NotContains(t, string(got), "SECRET")
+}

--- a/internal/client/retry.go
+++ b/internal/client/retry.go
@@ -1,0 +1,151 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"slices"
+	"time"
+)
+
+const bodyReadLimit = 4096
+
+type retrier struct {
+	wrapped    requestDoer
+	maxRetries int
+	backoff    BackoffFunc
+}
+
+// Do executes requests, retrying unsuccessful ones, when it safe to do so.
+//
+// Requests are passed to the wrapped [requestDoer], which is expected to act like a
+// [net/http.Client]. If the response status code indicates success or is unsafe to
+// retry, returns that response with a nil error. If the request context
+// expires or the retry attempt limit is reached, the response will be nil and
+// an error will be returned.
+func (r *retrier) Do(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+	var lastErr error
+
+	// The original request is discarded, make sure its body is closed.
+	defer func() {
+		if req.Body != nil {
+			_ = req.Body.Close()
+		}
+	}()
+
+	for attempts := 0; attempts < r.maxRetries+1; attempts++ {
+		clone, err := cloneRequest(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to clone request: %w", err)
+		}
+
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		resp, err := r.wrapped.Do(clone)
+		if err != nil {
+			if !isTransient(err) || !isIdempotent(clone.Method) {
+				return nil, err
+			}
+			lastErr = err
+		} else {
+			if isSuccessful(resp.StatusCode) || !safeToRetry(resp.StatusCode, clone.Method) {
+				return resp, nil
+			}
+			lastErr = fmt.Errorf("bad status: %q", resp.Status)
+
+			// Try to drain and close the body, so the connection is freed.
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, bodyReadLimit))
+			_ = resp.Body.Close()
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(r.backoff(attempts, resp)):
+		}
+	}
+
+	return nil, fmt.Errorf("max retries %d exceeded, last attempt: %w", r.maxRetries, lastErr)
+}
+
+func cloneRequest(ctx context.Context, req *http.Request) (*http.Request, error) {
+	c := req.Clone(ctx)
+	if req.Body == nil {
+		return c, nil
+	}
+
+	if req.GetBody == nil {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body: %w", err)
+		}
+		_ = req.Body.Close()
+
+		req.GetBody = func() (io.ReadCloser, error) {
+			buf := bytes.NewBuffer(body)
+			return io.NopCloser(buf), nil
+		}
+
+		req.Body, err = req.GetBody()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get request body: %w", err)
+		}
+	}
+
+	var err error
+
+	c.Body, err = req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func isTransient(err error) bool {
+	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) {
+			if netErr.Timeout() {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func isSuccessful(status int) bool {
+	return status >= 200 && status < 300
+}
+
+func isIdempotent(method string) bool {
+	return method != http.MethodConnect &&
+		method != http.MethodPost &&
+		method != http.MethodPatch
+}
+
+func safeToRetry(status int, method string) bool {
+	idempotentRetryable := []int{
+		http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	}
+	nonIdempotentRetryable := []int{
+		http.StatusServiceUnavailable,
+		http.StatusTooManyRequests,
+	}
+
+	if isIdempotent(method) {
+		return slices.Contains(idempotentRetryable, status)
+	}
+	return slices.Contains(nonIdempotentRetryable, status)
+}

--- a/internal/client/retry_test.go
+++ b/internal/client/retry_test.go
@@ -1,0 +1,296 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cherryservers/cherrygo/v3/internal/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupSpies(t *testing.T) (spyReadCloser, spyRoundTripper) {
+	t.Helper()
+
+	reqSpy := spyReadCloser{
+		real: io.NopCloser(strings.NewReader("test")),
+	}
+
+	respSpy := spyRoundTripper{
+		real: http.DefaultTransport,
+	}
+
+	return reqSpy, respSpy
+}
+
+type retryTestCase struct {
+	title          string
+	maxRetries     int
+	method         string
+	status         int
+	fn             http.HandlerFunc
+	reqCtx         context.Context
+	backoffFn      client.BackoffFunc
+	wantCalls      int
+	wantErr        bool
+	wantRespDrains int
+	wantBody       string
+}
+
+func testRetry(t *testing.T, tc retryTestCase) {
+	t.Run(tc.title, func(t *testing.T) {
+		reqSpy, respSpy := setupSpies(t)
+
+		httpClient := http.Client{
+			Transport: &respSpy,
+		}
+
+		client := client.New(
+			client.WithBackoff(tc.backoffFn),
+			client.WithHTTPClient(&httpClient),
+			client.WithMaxRetries(tc.maxRetries),
+		)
+		calls := 0
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tc.fn(w, r)
+			calls++
+		}))
+		defer ts.Close()
+
+		req, err := http.NewRequestWithContext(tc.reqCtx, tc.method, ts.URL, &reqSpy)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+
+		assert.Equal(t, tc.wantRespDrains, respSpy.rc.closes, "Unexpected number of response drains.")
+		assert.Equal(t, tc.wantRespDrains, respSpy.rc.reads, "Unexpected number of response drains.")
+		assert.Equal(t, 1, reqSpy.closes, "The original request body should be closed exactly once.")
+		assert.Equal(t, tc.wantCalls, calls, "Incorrect number HTTP server requests.")
+
+		if tc.wantErr {
+			assert.Error(t, err)
+			assert.Nil(t, resp)
+		} else {
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			body, readErr := io.ReadAll(resp.Body)
+			closeErr := resp.Body.Close()
+
+			assert.NoError(t, readErr)
+			assert.NoError(t, closeErr)
+			assert.Equal(t, tc.wantBody, string(body))
+		}
+	})
+}
+
+func TestRetry(t *testing.T) {
+	retryable := map[string][]int{
+		"GET":    {408, 429, 502, 503, 504},
+		"DELETE": {408, 429, 502, 503, 504},
+		"PUT":    {408, 429, 502, 503, 504},
+		"POST":   {429, 503},
+		"PATCH":  {429, 503},
+	}
+
+	for method, statuses := range retryable {
+		for _, status := range statuses {
+			calls := 0
+			testRetry(t, retryTestCase{
+				title:      fmt.Sprintf("succeed on retry: method %q, status %d", method, status),
+				maxRetries: 5,
+				method:     method,
+				status:     status,
+				fn: func(w http.ResponseWriter, _ *http.Request) {
+					if calls == 0 {
+						w.WriteHeader(status)
+						_, _ = fmt.Fprint(w, "error")
+					} else {
+						_, _ = fmt.Fprint(w, "test")
+					}
+					calls++
+				},
+				reqCtx:         t.Context(),
+				backoffFn:      testBackoff(),
+				wantCalls:      2,
+				wantErr:        false,
+				wantRespDrains: 1,
+				wantBody:       "test",
+			})
+			testRetry(t, retryTestCase{
+				title:      fmt.Sprintf("exceed max retries: method %q, status %d", method, status),
+				maxRetries: 5,
+				method:     method,
+				status:     status,
+				fn: func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(status)
+					_, _ = fmt.Fprint(w, "error")
+				},
+				reqCtx:         t.Context(),
+				backoffFn:      testBackoff(),
+				wantCalls:      6,
+				wantErr:        true,
+				wantRespDrains: 6,
+				wantBody:       "error",
+			})
+		}
+	}
+
+	unRetryable := map[string][]int{
+		"POST":  {408, 502, 504},
+		"PATCH": {408, 502, 504},
+	}
+
+	for method, statuses := range unRetryable {
+		for _, status := range statuses {
+			calls := 0
+			testRetry(t, retryTestCase{
+				title:      fmt.Sprintf("don't retry: method %q, status %d", method, status),
+				maxRetries: 5,
+				method:     method,
+				status:     status,
+				reqCtx:     t.Context(),
+				backoffFn:  testBackoff(),
+				fn: func(w http.ResponseWriter, _ *http.Request) {
+					if calls == 0 {
+						w.WriteHeader(status)
+						_, _ = fmt.Fprint(w, "error")
+					} else {
+						_, _ = fmt.Fprint(w, "test")
+					}
+					calls++
+				},
+				wantCalls:      1,
+				wantErr:        false,
+				wantRespDrains: 0,
+				wantBody:       "error",
+			})
+		}
+	}
+}
+
+type errorSpyRoundTripper struct {
+	err   error
+	calls int
+}
+
+func (e *errorSpyRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	e.calls++
+	return nil, e.err
+}
+
+type fakeNetError struct {
+	transient bool
+}
+
+func (e fakeNetError) Error() string {
+	return "test net error"
+}
+
+func (e fakeNetError) Temporary() bool {
+	return e.transient
+}
+
+func (e fakeNetError) Timeout() bool {
+	return e.transient
+}
+
+var _ net.Error = (*fakeNetError)(nil)
+
+func TestRetryNetworkError(t *testing.T) {
+	cases := []struct {
+		transient bool
+		wantCalls int
+		title     string
+	}{
+		{
+			title:     "don't retry non-transient net error",
+			transient: false,
+			wantCalls: 1,
+		},
+		{
+			title:     "retry transient net error",
+			transient: true,
+			wantCalls: 6,
+		},
+	}
+
+	for _, td := range cases {
+		t.Run(td.title, func(t *testing.T) {
+			reqSpy := spyReadCloser{
+				real: io.NopCloser(strings.NewReader("test")),
+			}
+
+			fakeErr := fakeNetError{
+				transient: td.transient,
+			}
+
+			rtSpy := errorSpyRoundTripper{
+				err: fakeErr,
+			}
+
+			httpClient := http.Client{
+				Transport: &rtSpy,
+			}
+
+			client := client.New(
+				client.WithBackoff(testBackoff()),
+				client.WithHTTPClient(&httpClient),
+				client.WithMaxRetries(5),
+			)
+
+			req, err := http.NewRequest("GET", "fake-url", &reqSpy)
+			require.NoError(t, err)
+
+			resp, err := client.Do(req)
+
+			assert.Error(t, err)
+			assert.Nil(t, resp)
+			assert.Equal(t, 1, reqSpy.closes, "The original request body should be closed exactly once.")
+			assert.Equal(t, td.wantCalls, rtSpy.calls)
+		})
+	}
+}
+
+func TestRetryContextCancellation(t *testing.T) {
+	calls := 0
+	reqCtx, cancel := context.WithCancel(t.Context())
+
+	var ctxCancelBackoff client.BackoffFunc = func(attempts int, _ *http.Response) time.Duration {
+		if attempts < 2 {
+			return time.Nanosecond
+		}
+		cancel()
+		return time.Second
+	}
+
+	testRetry(t, retryTestCase{
+		title:      "stop on request context cancellation",
+		maxRetries: 5,
+		method:     "GET",
+		status:     429,
+		fn: func(w http.ResponseWriter, _ *http.Request) {
+			if calls < 3 {
+				w.WriteHeader(429)
+				_, _ = fmt.Fprint(w, "error")
+			} else {
+				_, _ = fmt.Fprint(w, "test")
+			}
+			calls++
+		},
+		reqCtx:         reqCtx,
+		backoffFn:      ctxCancelBackoff,
+		wantCalls:      3,
+		wantErr:        true,
+		wantRespDrains: 3,
+		wantBody:       "",
+	})
+}

--- a/internal/client/spy_test.go
+++ b/internal/client/spy_test.go
@@ -1,0 +1,37 @@
+package client_test
+
+import (
+	"io"
+	"net/http"
+)
+
+type spyReadCloser struct {
+	closes int
+	reads  int
+	real   io.ReadCloser
+}
+
+func (s *spyReadCloser) Read(p []byte) (n int, err error) {
+	s.reads++
+	return s.real.Read(p)
+}
+
+func (s *spyReadCloser) Close() error {
+	s.closes++
+	return s.real.Close()
+}
+
+type spyRoundTripper struct {
+	rc   spyReadCloser
+	real http.RoundTripper
+}
+
+func (rt *spyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.real.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	rt.rc.real = resp.Body
+	resp.Body = &rt.rc
+	return resp, err
+}

--- a/ipaddresses.go
+++ b/ipaddresses.go
@@ -1,7 +1,9 @@
 package cherrygo
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 )
 
 const baseIpPath = "/v1/ips"
@@ -9,13 +11,13 @@ const baseIpPath = "/v1/ips"
 // IpAddressesService is an interface for interfacing with the the Server endpoints of the CherryServers API
 // See: https://api.cherryservers.com/doc/#tag/Ip-Addresses
 type IpAddressesService interface {
-	List(projectID int, opts *GetOptions) ([]IPAddress, *Response, error)
-	Get(ipID string, opts *GetOptions) (IPAddress, *Response, error)
-	Create(projectID int, request *CreateIPAddress) (IPAddress, *Response, error)
-	Remove(ipID string) (*Response, error)
-	Update(ipID string, request *UpdateIPAddress) (IPAddress, *Response, error)
-	Assign(ipID string, request *AssignIPAddress) (IPAddress, *Response, error)
-	Unassign(ipID string) (*Response, error)
+	List(ctx context.Context, projectID int, opts *GetOptions) ([]IPAddress, *Response, error)
+	Get(ctx context.Context, ipID string, opts *GetOptions) (IPAddress, *Response, error)
+	Create(ctx context.Context, projectID int, request *CreateIPAddress) (IPAddress, *Response, error)
+	Remove(ctx context.Context, ipID string) (*Response, error)
+	Update(ctx context.Context, ipID string, request *UpdateIPAddress) (IPAddress, *Response, error)
+	Assign(ctx context.Context, ipID string, request *AssignIPAddress) (IPAddress, *Response, error)
+	Unassign(ctx context.Context, ipID string) (*Response, error)
 }
 
 // IPAddresses fields
@@ -96,12 +98,16 @@ type AssignIPAddress struct {
 }
 
 // List func lists ip addresses
-func (i *IPsClient) List(projectID int, opts *GetOptions) ([]IPAddress, *Response, error) {
+func (i *IPsClient) List(ctx context.Context, projectID int, opts *GetOptions) ([]IPAddress, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("%s/%d/ips", baseProjectPath, projectID))
-
 	var trans []IPAddress
 
-	resp, err := i.client.MakeRequest("GET", path, nil, &trans)
+	req, err := i.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := i.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -110,12 +116,16 @@ func (i *IPsClient) List(projectID int, opts *GetOptions) ([]IPAddress, *Respons
 }
 
 // List func lists teams
-func (i *IPsClient) Get(ipID string, opts *GetOptions) (IPAddress, *Response, error) {
+func (i *IPsClient) Get(ctx context.Context, ipID string, opts *GetOptions) (IPAddress, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("%s/%s", baseIpPath, ipID))
-
 	var trans IPAddress
 
-	resp, err := i.client.MakeRequest("GET", path, nil, &trans)
+	req, err := i.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return IPAddress{}, nil, err
+	}
+
+	resp, err := i.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -124,12 +134,16 @@ func (i *IPsClient) Get(ipID string, opts *GetOptions) (IPAddress, *Response, er
 }
 
 // Create function orders new floating IP address
-func (i *IPsClient) Create(projectID int, request *CreateIPAddress) (IPAddress, *Response, error) {
+func (i *IPsClient) Create(ctx context.Context, projectID int, request *CreateIPAddress) (IPAddress, *Response, error) {
 	var trans IPAddress
-
 	path := fmt.Sprintf("%s/%d/ips", baseProjectPath, projectID)
 
-	resp, err := i.client.MakeRequest("POST", path, request, &trans)
+	req, err := i.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return IPAddress{}, nil, err
+	}
+
+	resp, err := i.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -138,12 +152,16 @@ func (i *IPsClient) Create(projectID int, request *CreateIPAddress) (IPAddress, 
 }
 
 // Update function updates existing IP address
-func (i *IPsClient) Update(ipID string, request *UpdateIPAddress) (IPAddress, *Response, error) {
+func (i *IPsClient) Update(ctx context.Context, ipID string, request *UpdateIPAddress) (IPAddress, *Response, error) {
 	var trans IPAddress
-
 	path := fmt.Sprintf("%s/%s", baseIpPath, ipID)
 
-	resp, err := i.client.MakeRequest("PUT", path, request, &trans)
+	req, err := i.client.NewRequest(ctx, http.MethodPut, path, request)
+	if err != nil {
+		return IPAddress{}, nil, err
+	}
+
+	resp, err := i.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -152,10 +170,15 @@ func (i *IPsClient) Update(ipID string, request *UpdateIPAddress) (IPAddress, *R
 }
 
 // Remove function removes existing project IP address
-func (i *IPsClient) Remove(ipID string) (*Response, error) {
+func (i *IPsClient) Remove(ctx context.Context, ipID string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", baseIpPath, ipID)
 
-	resp, err := i.client.MakeRequest("DELETE", path, nil, nil)
+	req, err := i.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := i.client.Do(req, nil)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -163,12 +186,16 @@ func (i *IPsClient) Remove(ipID string) (*Response, error) {
 	return resp, err
 }
 
-func (i *IPsClient) Assign(ipID string, request *AssignIPAddress) (IPAddress, *Response, error) {
+func (i *IPsClient) Assign(ctx context.Context, ipID string, request *AssignIPAddress) (IPAddress, *Response, error) {
 	var trans IPAddress
-
 	path := fmt.Sprintf("%s/%s", baseIpPath, ipID)
 
-	resp, err := i.client.MakeRequest("PUT", path, request, &trans)
+	req, err := i.client.NewRequest(ctx, http.MethodPut, path, request)
+	if err != nil {
+		return IPAddress{}, nil, err
+	}
+
+	resp, err := i.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -176,15 +203,18 @@ func (i *IPsClient) Assign(ipID string, request *AssignIPAddress) (IPAddress, *R
 	return trans, resp, err
 }
 
-func (i *IPsClient) Unassign(ipID string) (*Response, error) {
-	var trans IPAddress
-
+func (i *IPsClient) Unassign(ctx context.Context, ipID string) (*Response, error) {
 	path := fmt.Sprintf("%s/%s", baseIpPath, ipID)
 	request := UpdateIPAddress{
 		TargetedTo: "0",
 	}
 
-	resp, err := i.client.MakeRequest("PUT", path, request, &trans)
+	req, err := i.client.NewRequest(ctx, http.MethodPut, path, request)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := i.client.Do(req, nil)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}

--- a/ipaddresses_test.go
+++ b/ipaddresses_test.go
@@ -7,6 +7,9 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIpAddresses_List(t *testing.T) {
@@ -68,7 +71,6 @@ func TestIpAddresses_List(t *testing.T) {
 	})
 
 	ips, _, err := testClient.IPAddresses.List(t.Context(), projectID, nil)
-
 	if err != nil {
 		t.Errorf("IPAddresses.List returned %+v", err)
 	}
@@ -319,8 +321,54 @@ func TestIpAddress_Delete(t *testing.T) {
 	})
 
 	_, err := testClient.IPAddresses.Remove(t.Context(), ipId)
-
 	if err != nil {
 		t.Errorf("IPAddress.Remove returned %+v", err)
 	}
+}
+
+func TestIPAddress_Assign(t *testing.T) {
+	setup()
+	defer teardown()
+
+	assignRequest := AssignIPAddress{
+		ServerID: 123,
+	}
+
+	mux.HandleFunc("PUT /v1/ips/abc123", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+
+		v := new(AssignIPAddress)
+		err := json.NewDecoder(r.Body).Decode(v)
+		require.NoError(t, err)
+
+		assert.Equal(t, assignRequest, *v)
+
+		fmt.Fprint(w, `{"id": "abc123", "address": "127.0.0.1"}`)
+	})
+
+	ip, _, err := testClient.IPAddresses.Assign(t.Context(), "abc123", &assignRequest)
+	require.NoError(t, err)
+
+	assert.Equal(t, "abc123", ip.ID)
+	assert.Equal(t, "127.0.0.1", ip.Address)
+}
+
+func TestIPAddress_Unassign(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("PUT /v1/ips/abc123", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPut)
+
+		v := new(UpdateIPAddress)
+		err := json.NewDecoder(r.Body).Decode(v)
+		require.NoError(t, err)
+
+		assert.Equal(t, "0", v.TargetedTo)
+
+		fmt.Fprint(w, `{"id": "abc123", "address": "127.0.0.1"}`)
+	})
+
+	_, err := testClient.IPAddresses.Unassign(t.Context(), "abc123")
+	require.NoError(t, err)
 }

--- a/ipaddresses_test.go
+++ b/ipaddresses_test.go
@@ -67,7 +67,7 @@ func TestIpAddresses_List(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	ips, _, err := testClient.IPAddresses.List(projectID, nil)
+	ips, _, err := testClient.IPAddresses.List(t.Context(), projectID, nil)
 
 	if err != nil {
 		t.Errorf("IPAddresses.List returned %+v", err)
@@ -160,7 +160,7 @@ func TestIpAddress_Get(t *testing.T) {
 		 }`)
 	})
 
-	ip, _, err := testClient.IPAddresses.Get(ipUID, nil)
+	ip, _, err := testClient.IPAddresses.Get(t.Context(), ipUID, nil)
 	if err != nil {
 		t.Errorf("IPAddress.List returned %+v", err)
 	}
@@ -241,7 +241,7 @@ func TestIpAddress_Create(t *testing.T) {
 		Tags:      &tags,
 	}
 
-	ipAddress, _, err := testClient.IPAddresses.Create(projectID, &ipCreate)
+	ipAddress, _, err := testClient.IPAddresses.Create(t.Context(), projectID, &ipCreate)
 	if err != nil {
 		t.Errorf("IPAddress.Create returned %+v", err)
 	}
@@ -294,7 +294,7 @@ func TestIpAddress_Update(t *testing.T) {
 		Tags:      &tags,
 	}
 
-	ipAddress, _, err := testClient.IPAddresses.Update(ipId, &ipUpdate)
+	ipAddress, _, err := testClient.IPAddresses.Update(t.Context(), ipId, &ipUpdate)
 	if err != nil {
 		t.Errorf("IPAddress.Update returned %+v", err)
 	}
@@ -318,7 +318,7 @@ func TestIpAddress_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := testClient.IPAddresses.Remove(ipId)
+	_, err := testClient.IPAddresses.Remove(t.Context(), ipId)
 
 	if err != nil {
 		t.Errorf("IPAddress.Remove returned %+v", err)

--- a/ipaddresses_test.go
+++ b/ipaddresses_test.go
@@ -67,7 +67,7 @@ func TestIpAddresses_List(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	ips, _, err := client.IPAddresses.List(projectID, nil)
+	ips, _, err := testClient.IPAddresses.List(projectID, nil)
 
 	if err != nil {
 		t.Errorf("IPAddresses.List returned %+v", err)
@@ -160,7 +160,7 @@ func TestIpAddress_Get(t *testing.T) {
 		 }`)
 	})
 
-	ip, _, err := client.IPAddresses.Get(ipUID, nil)
+	ip, _, err := testClient.IPAddresses.Get(ipUID, nil)
 	if err != nil {
 		t.Errorf("IPAddress.List returned %+v", err)
 	}
@@ -241,7 +241,7 @@ func TestIpAddress_Create(t *testing.T) {
 		Tags:      &tags,
 	}
 
-	ipAddress, _, err := client.IPAddresses.Create(projectID, &ipCreate)
+	ipAddress, _, err := testClient.IPAddresses.Create(projectID, &ipCreate)
 	if err != nil {
 		t.Errorf("IPAddress.Create returned %+v", err)
 	}
@@ -294,7 +294,7 @@ func TestIpAddress_Update(t *testing.T) {
 		Tags:      &tags,
 	}
 
-	ipAddress, _, err := client.IPAddresses.Update(ipId, &ipUpdate)
+	ipAddress, _, err := testClient.IPAddresses.Update(ipId, &ipUpdate)
 	if err != nil {
 		t.Errorf("IPAddress.Update returned %+v", err)
 	}
@@ -318,7 +318,7 @@ func TestIpAddress_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := client.IPAddresses.Remove(ipId)
+	_, err := testClient.IPAddresses.Remove(ipId)
 
 	if err != nil {
 		t.Errorf("IPAddress.Remove returned %+v", err)

--- a/plans.go
+++ b/plans.go
@@ -1,18 +1,22 @@
 package cherrygo
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 )
 
-const teamPlanPath = "/v1/teams"
-const basePlanPath = "/v1/plans"
+const (
+	teamPlanPath = "/v1/teams"
+	basePlanPath = "/v1/plans"
+)
 
 // PlansService is an interface for interfacing with the Plan endpoints of the CherryServers API
 // See: https://api.cherryservers.com/doc/#tag/Plans
 type PlansService interface {
-	List(teamID int, opts *GetOptions) ([]Plan, *Response, error)
-	GetBySlug(slug string, opts *GetOptions) (Plan, *Response, error)
-	GetByID(id int, opts *GetOptions) (Plan, *Response, error)
+	List(ctx context.Context, teamID int, opts *GetOptions) ([]Plan, *Response, error)
+	GetBySlug(ctx context.Context, slug string, opts *GetOptions) (Plan, *Response, error)
+	GetByID(ctx context.Context, id int, opts *GetOptions) (Plan, *Response, error)
 }
 
 type Plan struct {
@@ -98,7 +102,7 @@ type PlansClient struct {
 }
 
 // List func lists plans
-func (p *PlansClient) List(teamID int, opts *GetOptions) ([]Plan, *Response, error) {
+func (p *PlansClient) List(ctx context.Context, teamID int, opts *GetOptions) ([]Plan, *Response, error) {
 	basePath := basePlanPath
 	if teamID != 0 {
 		basePath = fmt.Sprintf("%s/%d/plans", teamPlanPath, teamID)
@@ -107,7 +111,12 @@ func (p *PlansClient) List(teamID int, opts *GetOptions) ([]Plan, *Response, err
 	path := opts.WithQuery(basePath)
 	var trans []Plan
 
-	resp, err := p.client.MakeRequest("GET", path, nil, &trans)
+	req, err := p.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := p.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -115,10 +124,15 @@ func (p *PlansClient) List(teamID int, opts *GetOptions) ([]Plan, *Response, err
 	return trans, resp, err
 }
 
-func (p *PlansClient) get(path string, opts *GetOptions) (Plan, *Response, error) {
+func (p *PlansClient) get(ctx context.Context, path string, opts *GetOptions) (Plan, *Response, error) {
 	var trans Plan
 
-	resp, err := p.client.MakeRequest("GET", path, nil, &trans)
+	req, err := p.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return Plan{}, nil, err
+	}
+
+	resp, err := p.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("error: %v", err)
 	}
@@ -126,14 +140,14 @@ func (p *PlansClient) get(path string, opts *GetOptions) (Plan, *Response, error
 	return trans, resp, err
 }
 
-func (p *PlansClient) GetByID(id int, opts *GetOptions) (Plan, *Response, error) {
+func (p *PlansClient) GetByID(ctx context.Context, id int, opts *GetOptions) (Plan, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("%s/%d", basePlanPath, id))
 
-	return p.get(path, opts)
+	return p.get(ctx, path, opts)
 }
 
-func (p *PlansClient) GetBySlug(slug string, opts *GetOptions) (Plan, *Response, error) {
+func (p *PlansClient) GetBySlug(ctx context.Context, slug string, opts *GetOptions) (Plan, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("%s/%s", basePlanPath, slug))
 
-	return p.get(path, opts)
+	return p.get(ctx, path, opts)
 }

--- a/plans_test.go
+++ b/plans_test.go
@@ -6,6 +6,9 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPlans_List(t *testing.T) {
@@ -56,7 +59,7 @@ func TestPlans_List(t *testing.T) {
 					Size:  20,
 					Unit:  "GB",
 				}},
-				//Raid: Raid{},
+				// Raid: Raid{},
 				Nics: Nics{
 					Name: "1Gbps",
 				},
@@ -78,11 +81,13 @@ func TestPlans_List(t *testing.T) {
 				},
 			},
 			Category: "Shared resources",
-			Softwares: []SoftwareImage{{
-				Image: SoftwareImageSpecs{
-					Name: "Ubuntu 24.04 64bit",
-					Slug: "ubuntu_24_04_64bit",
-				}},
+			Softwares: []SoftwareImage{
+				{
+					Image: SoftwareImageSpecs{
+						Name: "Ubuntu 24.04 64bit",
+						Slug: "ubuntu_24_04_64bit",
+					},
+				},
 			},
 		},
 	}
@@ -90,4 +95,42 @@ func TestPlans_List(t *testing.T) {
 	if !reflect.DeepEqual(plans, expected) {
 		t.Errorf("Plans.List  plans returned %+v, expected %+v", plans, expected)
 	}
+}
+
+func TestPlans_GetByID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("GET /v1/plans/123", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id": 123, "name": "test-name", "slug": "test-slug"}`)
+	})
+
+	plan, _, err := testClient.Plans.GetByID(t.Context(), 123, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 123, plan.ID)
+	assert.Equal(t, "test-name", plan.Name)
+	assert.Equal(t, "test-slug", plan.Slug)
+}
+
+func TestPlans_GetBySlug(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("GET /v1/plans/test-plan", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id": 123, "name": "test-name", "slug": "test-slug"}`)
+	})
+
+	plan, _, err := testClient.Plans.GetBySlug(t.Context(), "test-plan", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 123, plan.ID)
+	assert.Equal(t, "test-name", plan.Name)
+	assert.Equal(t, "test-slug", plan.Slug)
 }

--- a/plans_test.go
+++ b/plans_test.go
@@ -18,7 +18,7 @@ func TestPlans_List(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	plans, _, err := client.Plans.List(teamID, nil)
+	plans, _, err := testClient.Plans.List(teamID, nil)
 	if err != nil {
 		t.Errorf("Plans.List returned %+v", err)
 	}

--- a/plans_test.go
+++ b/plans_test.go
@@ -18,7 +18,7 @@ func TestPlans_List(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	plans, _, err := testClient.Plans.List(teamID, nil)
+	plans, _, err := testClient.Plans.List(t.Context(), teamID, nil)
 	if err != nil {
 		t.Errorf("Plans.List returned %+v", err)
 	}

--- a/projects.go
+++ b/projects.go
@@ -1,7 +1,9 @@
 package cherrygo
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 )
 
 const baseProjectPath = "/v1/projects"
@@ -9,12 +11,12 @@ const baseProjectPath = "/v1/projects"
 // ProjectsService is an interface for interfacing with the Projects endpoints of the CherryServers API
 // See: https://api.cherryservers.com/doc/#tag/Projects
 type ProjectsService interface {
-	List(teamID int, opts *GetOptions) ([]Project, *Response, error)
-	Get(projectID int, opts *GetOptions) (Project, *Response, error)
-	Create(teamID int, request *CreateProject) (Project, *Response, error)
-	Update(projectID int, request *UpdateProject) (Project, *Response, error)
-	ListSSHKeys(projectID int, opts *GetOptions) ([]SSHKey, *Response, error)
-	Delete(projectID int) (*Response, error)
+	List(ctx context.Context, teamID int, opts *GetOptions) ([]Project, *Response, error)
+	Get(ctx context.Context, projectID int, opts *GetOptions) (Project, *Response, error)
+	Create(ctx context.Context, teamID int, request *CreateProject) (Project, *Response, error)
+	Update(ctx context.Context, projectID int, request *UpdateProject) (Project, *Response, error)
+	ListSSHKeys(ctx context.Context, projectID int, opts *GetOptions) ([]SSHKey, *Response, error)
+	Delete(ctx context.Context, projectID int) (*Response, error)
 }
 
 type Project struct {
@@ -41,12 +43,16 @@ type ProjectsClient struct {
 }
 
 // List func lists projects
-func (p *ProjectsClient) List(teamID int, opts *GetOptions) ([]Project, *Response, error) {
+func (p *ProjectsClient) List(ctx context.Context, teamID int, opts *GetOptions) ([]Project, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("/v1/teams/%d/projects", teamID))
-
 	var trans []Project
 
-	resp, err := p.client.MakeRequest("GET", path, nil, &trans)
+	req, err := p.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := p.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -54,12 +60,16 @@ func (p *ProjectsClient) List(teamID int, opts *GetOptions) ([]Project, *Respons
 	return trans, resp, err
 }
 
-func (p *ProjectsClient) Get(projectID int, opts *GetOptions) (Project, *Response, error) {
+func (p *ProjectsClient) Get(ctx context.Context, projectID int, opts *GetOptions) (Project, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("%s/%d", baseProjectPath, projectID))
-
 	var trans Project
 
-	resp, err := p.client.MakeRequest("GET", path, nil, &trans)
+	req, err := p.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return Project{}, nil, err
+	}
+
+	resp, err := p.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -68,12 +78,16 @@ func (p *ProjectsClient) Get(projectID int, opts *GetOptions) (Project, *Respons
 }
 
 // Create func will create new Project for specified team
-func (p *ProjectsClient) Create(teamID int, request *CreateProject) (Project, *Response, error) {
+func (p *ProjectsClient) Create(ctx context.Context, teamID int, request *CreateProject) (Project, *Response, error) {
 	var trans Project
-
 	path := fmt.Sprintf("/v1/teams/%d/projects", teamID)
 
-	resp, err := p.client.MakeRequest("POST", path, request, &trans)
+	req, err := p.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return Project{}, nil, err
+	}
+
+	resp, err := p.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -82,12 +96,16 @@ func (p *ProjectsClient) Create(teamID int, request *CreateProject) (Project, *R
 }
 
 // Update func will update a project
-func (p *ProjectsClient) Update(projectID int, request *UpdateProject) (Project, *Response, error) {
+func (p *ProjectsClient) Update(ctx context.Context, projectID int, request *UpdateProject) (Project, *Response, error) {
 	var trans Project
-
 	path := fmt.Sprintf("%s/%d", baseProjectPath, projectID)
 
-	resp, err := p.client.MakeRequest("PUT", path, request, &trans)
+	req, err := p.client.NewRequest(ctx, http.MethodPut, path, request)
+	if err != nil {
+		return Project{}, nil, err
+	}
+
+	resp, err := p.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -96,10 +114,15 @@ func (p *ProjectsClient) Update(projectID int, request *UpdateProject) (Project,
 }
 
 // Delete func will delete a project
-func (p *ProjectsClient) Delete(projectID int) (*Response, error) {
+func (p *ProjectsClient) Delete(ctx context.Context, projectID int) (*Response, error) {
 	path := fmt.Sprintf("%s/%d", baseProjectPath, projectID)
 
-	resp, err := p.client.MakeRequest("DELETE", path, nil, nil)
+	req, err := p.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := p.client.Do(req, nil)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -107,12 +130,16 @@ func (p *ProjectsClient) Delete(projectID int) (*Response, error) {
 	return resp, err
 }
 
-func (p *ProjectsClient) ListSSHKeys(projectID int, opts *GetOptions) ([]SSHKey, *Response, error) {
+func (p *ProjectsClient) ListSSHKeys(ctx context.Context, projectID int, opts *GetOptions) ([]SSHKey, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("/v1/projects/%d/ssh-keys", projectID))
-
 	var trans []SSHKey
 
-	resp, err := p.client.MakeRequest("GET", path, nil, &trans)
+	req, err := p.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := p.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}

--- a/projects_test.go
+++ b/projects_test.go
@@ -43,7 +43,7 @@ func TestProjects_List(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	projects, _, err := client.Projects.List(teamID, nil)
+	projects, _, err := testClient.Projects.List(teamID, nil)
 
 	if err != nil {
 		t.Errorf("Projects.List returned %+v", err)
@@ -81,7 +81,7 @@ func TestProject_Get(t *testing.T) {
 		}`)
 	})
 
-	project, _, err := client.Projects.Get(projectID, nil)
+	project, _, err := testClient.Projects.Get(projectID, nil)
 	if err != nil {
 		t.Errorf("Project.List returned %+v", err)
 	}
@@ -131,7 +131,7 @@ func TestProject_Create(t *testing.T) {
 		Name: "My Custom Project",
 	}
 
-	project, _, err := client.Projects.Create(teamID, &projectCreate)
+	project, _, err := testClient.Projects.Create(teamID, &projectCreate)
 	if err != nil {
 		t.Errorf("Project.Create returned %+v", err)
 	}
@@ -174,7 +174,7 @@ func TestProject_Update(t *testing.T) {
 		Bgp:  &bgp,
 	}
 
-	_, _, err := client.Projects.Update(projectID, &projectUpdate)
+	_, _, err := testClient.Projects.Update(projectID, &projectUpdate)
 	if err != nil {
 		t.Errorf("Project.Update returned %+v", err)
 	}
@@ -192,7 +192,7 @@ func TestProject_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := client.Projects.Delete(projectID)
+	_, err := testClient.Projects.Delete(projectID)
 
 	if err != nil {
 		t.Errorf("Project.Delete returned %+v", err)
@@ -224,7 +224,7 @@ func TestProjectSSHKeys_List(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	sshKeys, _, err := client.Projects.ListSSHKeys(123, nil)
+	sshKeys, _, err := testClient.Projects.ListSSHKeys(123, nil)
 	if err != nil {
 		t.Errorf("Projects.ListSSHKeys returned %+v", err)
 	}

--- a/projects_test.go
+++ b/projects_test.go
@@ -43,7 +43,7 @@ func TestProjects_List(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	projects, _, err := testClient.Projects.List(teamID, nil)
+	projects, _, err := testClient.Projects.List(t.Context(), teamID, nil)
 
 	if err != nil {
 		t.Errorf("Projects.List returned %+v", err)
@@ -81,7 +81,7 @@ func TestProject_Get(t *testing.T) {
 		}`)
 	})
 
-	project, _, err := testClient.Projects.Get(projectID, nil)
+	project, _, err := testClient.Projects.Get(t.Context(), projectID, nil)
 	if err != nil {
 		t.Errorf("Project.List returned %+v", err)
 	}
@@ -131,7 +131,7 @@ func TestProject_Create(t *testing.T) {
 		Name: "My Custom Project",
 	}
 
-	project, _, err := testClient.Projects.Create(teamID, &projectCreate)
+	project, _, err := testClient.Projects.Create(t.Context(), teamID, &projectCreate)
 	if err != nil {
 		t.Errorf("Project.Create returned %+v", err)
 	}
@@ -174,7 +174,7 @@ func TestProject_Update(t *testing.T) {
 		Bgp:  &bgp,
 	}
 
-	_, _, err := testClient.Projects.Update(projectID, &projectUpdate)
+	_, _, err := testClient.Projects.Update(t.Context(), projectID, &projectUpdate)
 	if err != nil {
 		t.Errorf("Project.Update returned %+v", err)
 	}
@@ -192,7 +192,7 @@ func TestProject_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := testClient.Projects.Delete(projectID)
+	_, err := testClient.Projects.Delete(t.Context(), projectID)
 
 	if err != nil {
 		t.Errorf("Project.Delete returned %+v", err)
@@ -224,7 +224,7 @@ func TestProjectSSHKeys_List(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	sshKeys, _, err := testClient.Projects.ListSSHKeys(123, nil)
+	sshKeys, _, err := testClient.Projects.ListSSHKeys(t.Context(), 123, nil)
 	if err != nil {
 		t.Errorf("Projects.ListSSHKeys returned %+v", err)
 	}

--- a/regions.go
+++ b/regions.go
@@ -1,14 +1,18 @@
 package cherrygo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
 
 const baseRegionPath = "/v1/regions"
 
 // RegionsService is an interface for interfacing with the the Images endpoints of the CherryServers API
 // See: https://api.cherryservers.com/doc/#tag/Regions
 type RegionsService interface {
-	List(opts *GetOptions) ([]Region, *Response, error)
-	Get(region string, opts *GetOptions) (Region, *Response, error)
+	List(ctx context.Context, opts *GetOptions) ([]Region, *Response, error)
+	Get(ctx context.Context, region string, opts *GetOptions) (Region, *Response, error)
 }
 
 // Region fields
@@ -26,11 +30,16 @@ type RegionsClient struct {
 	client *Client
 }
 
-func (i *RegionsClient) List(opts *GetOptions) ([]Region, *Response, error) {
+func (i *RegionsClient) List(ctx context.Context, opts *GetOptions) ([]Region, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("%s", baseRegionPath))
 	var trans []Region
 
-	resp, err := i.client.MakeRequest("GET", path, nil, &trans)
+	req, err := i.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := i.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -38,11 +47,16 @@ func (i *RegionsClient) List(opts *GetOptions) ([]Region, *Response, error) {
 	return trans, resp, err
 }
 
-func (i *RegionsClient) Get(region string, opts *GetOptions) (Region, *Response, error) {
+func (i *RegionsClient) Get(ctx context.Context, region string, opts *GetOptions) (Region, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("%s/%s", baseRegionPath, region))
 	var trans Region
 
-	resp, err := i.client.MakeRequest("GET", path, nil, &trans)
+	req, err := i.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return Region{}, nil, err
+	}
+
+	resp, err := i.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}

--- a/regions_test.go
+++ b/regions_test.go
@@ -48,7 +48,7 @@ func TestRegions_List(t *testing.T) {
 		]`)
 	})
 
-	regions, _, err := testClient.Regions.List(nil)
+	regions, _, err := testClient.Regions.List(t.Context(), nil)
 	if err != nil {
 		t.Errorf("Regions.List returned %+v", err)
 	}
@@ -81,7 +81,7 @@ func TestRegion_Get(t *testing.T) {
 		}`)
 	})
 
-	region, _, err := testClient.Regions.Get("eu_nord_1", nil)
+	region, _, err := testClient.Regions.Get(t.Context(), "eu_nord_1", nil)
 	if err != nil {
 		t.Errorf("Regions.Get returned %+v", err)
 	}

--- a/regions_test.go
+++ b/regions_test.go
@@ -48,7 +48,7 @@ func TestRegions_List(t *testing.T) {
 		]`)
 	})
 
-	regions, _, err := client.Regions.List(nil)
+	regions, _, err := testClient.Regions.List(nil)
 	if err != nil {
 		t.Errorf("Regions.List returned %+v", err)
 	}
@@ -81,7 +81,7 @@ func TestRegion_Get(t *testing.T) {
 		}`)
 	})
 
-	region, _, err := client.Regions.Get("eu_nord_1", nil)
+	region, _, err := testClient.Regions.Get("eu_nord_1", nil)
 	if err != nil {
 		t.Errorf("Regions.Get returned %+v", err)
 	}

--- a/servers.go
+++ b/servers.go
@@ -1,31 +1,35 @@
 package cherrygo
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 )
 
-const baseServerPath = "/v1/servers"
-const endServersPath = "servers"
+const (
+	baseServerPath = "/v1/servers"
+	endServersPath = "servers"
+)
 
 // ServersService is an interface for interfacing with the Server endpoints of the CherryServers API
 // See: https://api.cherryservers.com/doc/#tag/Servers
 type ServersService interface {
-	List(projectID int, opts *GetOptions) ([]Server, *Response, error)
-	Get(serverID int, opts *GetOptions) (Server, *Response, error)
-	PowerOff(serverID int) (Server, *Response, error)
-	PowerOn(serverID int) (Server, *Response, error)
-	Create(request *CreateServer) (Server, *Response, error)
-	Delete(serverID int) (Server, *Response, error)
-	PowerState(serverID int) (PowerState, *Response, error)
-	Reboot(serverID int) (Server, *Response, error)
-	EnterRescueMode(serverID int, fields *RescueServerFields) (Server, *Response, error)
-	ExitRescueMode(serverID int) (Server, *Response, error)
-	Update(serverID int, request *UpdateServer) (Server, *Response, error)
-	Reinstall(serverID int, fields *ReinstallServerFields) (Server, *Response, error)
-	ListSSHKeys(serverID int, opts *GetOptions) ([]SSHKey, *Response, error)
-	ResetBMCPassword(serverID int) (Server, *Response, error)
-	ListCycles(opts *GetOptions) ([]ServerCycle, *Response, error)
-	Upgrade(serverID int, plan string) (Server, *Response, error)
+	List(ctx context.Context, projectID int, opts *GetOptions) ([]Server, *Response, error)
+	Get(ctx context.Context, serverID int, opts *GetOptions) (Server, *Response, error)
+	PowerOff(ctx context.Context, serverID int) (Server, *Response, error)
+	PowerOn(ctx context.Context, serverID int) (Server, *Response, error)
+	Create(ctx context.Context, request *CreateServer) (Server, *Response, error)
+	Delete(ctx context.Context, serverID int) (Server, *Response, error)
+	PowerState(ctx context.Context, serverID int) (PowerState, *Response, error)
+	Reboot(ctx context.Context, serverID int) (Server, *Response, error)
+	EnterRescueMode(ctx context.Context, serverID int, fields *RescueServerFields) (Server, *Response, error)
+	ExitRescueMode(ctx context.Context, serverID int) (Server, *Response, error)
+	Update(ctx context.Context, serverID int, request *UpdateServer) (Server, *Response, error)
+	Reinstall(ctx context.Context, serverID int, fields *ReinstallServerFields) (Server, *Response, error)
+	ListSSHKeys(ctx context.Context, serverID int, opts *GetOptions) ([]SSHKey, *Response, error)
+	ResetBMCPassword(ctx context.Context, serverID int) (Server, *Response, error)
+	ListCycles(ctx context.Context, opts *GetOptions) ([]ServerCycle, *Response, error)
+	Upgrade(ctx context.Context, serverID int, plan string) (Server, *Response, error)
 }
 
 // Server response object
@@ -144,11 +148,16 @@ type ServersClient struct {
 }
 
 // List func lists teams
-func (s *ServersClient) List(projectID int, opts *GetOptions) ([]Server, *Response, error) {
+func (s *ServersClient) List(ctx context.Context, projectID int, opts *GetOptions) ([]Server, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("/v1/projects/%d/servers", projectID))
-
 	var trans []Server
-	resp, err := s.client.MakeRequest("GET", path, nil, &trans)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -156,12 +165,16 @@ func (s *ServersClient) List(projectID int, opts *GetOptions) ([]Server, *Respon
 	return trans, resp, err
 }
 
-func (s *ServersClient) Get(serverID int, opts *GetOptions) (Server, *Response, error) {
+func (s *ServersClient) Get(ctx context.Context, serverID int, opts *GetOptions) (Server, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("%s/%d", baseServerPath, serverID))
-
 	var trans Server
 
-	resp, err := s.client.MakeRequest("GET", path, nil, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return Server{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -169,97 +182,129 @@ func (s *ServersClient) Get(serverID int, opts *GetOptions) (Server, *Response, 
 	return trans, resp, err
 }
 
-func (s *ServersClient) action(serverID int, serverAction ServerAction) (Server, *Response, error) {
+func (s *ServersClient) action(ctx context.Context, serverID int, serverAction ServerAction) (Server, *Response, error) {
 	var trans Server
-
 	path := fmt.Sprintf("%s/%d/actions", baseServerPath, serverID)
-	resp, err := s.client.MakeRequest("POST", path, serverAction, &trans)
 
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, serverAction)
+	if err != nil {
+		return Server{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	return trans, resp, err
 }
 
 // PowerOff function turns server off
-func (s *ServersClient) PowerOff(serverID int) (Server, *Response, error) {
+func (s *ServersClient) PowerOff(ctx context.Context, serverID int) (Server, *Response, error) {
 	action := ServerAction{
 		Type: "power_off",
 	}
 
-	return s.action(serverID, action)
+	return s.action(ctx, serverID, action)
 }
 
 // PowerOn function turns server on
-func (s *ServersClient) PowerOn(serverID int) (Server, *Response, error) {
+func (s *ServersClient) PowerOn(ctx context.Context, serverID int) (Server, *Response, error) {
 	action := ServerAction{
 		Type: "power_on",
 	}
 
-	return s.action(serverID, action)
+	return s.action(ctx, serverID, action)
 }
 
 // Reboot function restarts desired server
-func (s *ServersClient) Reboot(serverID int) (Server, *Response, error) {
+func (s *ServersClient) Reboot(ctx context.Context, serverID int) (Server, *Response, error) {
 	action := ServerAction{
 		Type: "reboot",
 	}
 
-	return s.action(serverID, action)
+	return s.action(ctx, serverID, action)
 }
 
-func (s *ServersClient) EnterRescueMode(serverID int, fields *RescueServerFields) (Server, *Response, error) {
+func (s *ServersClient) EnterRescueMode(ctx context.Context, serverID int, fields *RescueServerFields) (Server, *Response, error) {
 	var trans Server
-
 	request := &RescueServer{ServerAction{Type: "enter-rescue-mode"}, fields}
 	path := fmt.Sprintf("%s/%d/actions", baseServerPath, serverID)
-	resp, err := s.client.MakeRequest("POST", path, request, &trans)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return Server{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
+	if err != nil {
+		err = fmt.Errorf("Error: %v", err)
+	}
 
 	return trans, resp, err
 }
 
-func (s *ServersClient) ExitRescueMode(serverID int) (Server, *Response, error) {
+func (s *ServersClient) ExitRescueMode(ctx context.Context, serverID int) (Server, *Response, error) {
 	action := ServerAction{
 		Type: "exit-rescue-mode",
 	}
 
-	return s.action(serverID, action)
+	return s.action(ctx, serverID, action)
 }
 
-func (s *ServersClient) ResetBMCPassword(serverID int) (Server, *Response, error) {
+func (s *ServersClient) ResetBMCPassword(ctx context.Context, serverID int) (Server, *Response, error) {
 	action := ServerAction{
 		Type: "reset-bmc-password",
 	}
 
-	return s.action(serverID, action)
+	return s.action(ctx, serverID, action)
 }
 
-func (s *ServersClient) Reinstall(serverID int, fields *ReinstallServerFields) (Server, *Response, error) {
+func (s *ServersClient) Reinstall(ctx context.Context, serverID int, fields *ReinstallServerFields) (Server, *Response, error) {
 	var trans Server
-
 	request := &ReinstallServer{ServerAction{Type: "reinstall"}, fields}
 	path := fmt.Sprintf("%s/%d/actions", baseServerPath, serverID)
-	resp, err := s.client.MakeRequest("POST", path, request, &trans)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return Server{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
+	if err != nil {
+		err = fmt.Errorf("Error: %v", err)
+	}
 
 	return trans, resp, err
 }
 
-func (s *ServersClient) Upgrade(serverID int, plan string) (Server, *Response, error) {
+func (s *ServersClient) Upgrade(ctx context.Context, serverID int, plan string) (Server, *Response, error) {
 	var trans Server
-
 	request := &UpgradeServer{
 		ServerAction: ServerAction{Type: "upgrade"},
 		Plan:         plan,
 	}
 	path := fmt.Sprintf("%s/%d/actions", baseServerPath, serverID)
-	resp, err := s.client.MakeRequest("POST", path, request, &trans)
+
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return Server{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
+	if err != nil {
+		err = fmt.Errorf("Error: %v", err)
+	}
 
 	return trans, resp, err
 }
 
-func (s *ServersClient) PowerState(serverID int) (PowerState, *Response, error) {
+func (s *ServersClient) PowerState(ctx context.Context, serverID int) (PowerState, *Response, error) {
 	path := fmt.Sprintf("%s/%d?fields=power", baseServerPath, serverID)
-
 	var trans PowerState
 
-	resp, err := s.client.MakeRequest("GET", path, nil, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return PowerState{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -267,12 +312,16 @@ func (s *ServersClient) PowerState(serverID int) (PowerState, *Response, error) 
 	return trans, resp, err
 }
 
-func (s *ServersClient) Create(request *CreateServer) (Server, *Response, error) {
+func (s *ServersClient) Create(ctx context.Context, request *CreateServer) (Server, *Response, error) {
 	var trans Server
-
 	path := fmt.Sprintf("/v1/projects/%d/servers", request.ProjectID)
-	resp, err := s.client.MakeRequest("POST", path, request, &trans)
 
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return Server{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -280,12 +329,16 @@ func (s *ServersClient) Create(request *CreateServer) (Server, *Response, error)
 	return trans, resp, err
 }
 
-func (s *ServersClient) Update(serverID int, request *UpdateServer) (Server, *Response, error) {
+func (s *ServersClient) Update(ctx context.Context, serverID int, request *UpdateServer) (Server, *Response, error) {
 	var trans Server
-
 	path := fmt.Sprintf("%s/%d", baseServerPath, serverID)
-	resp, err := s.client.MakeRequest("PUT", path, request, &trans)
 
+	req, err := s.client.NewRequest(ctx, http.MethodPut, path, request)
+	if err != nil {
+		return Server{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -293,12 +346,16 @@ func (s *ServersClient) Update(serverID int, request *UpdateServer) (Server, *Re
 	return trans, resp, err
 }
 
-func (s *ServersClient) Delete(serverID int) (Server, *Response, error) {
+func (s *ServersClient) Delete(ctx context.Context, serverID int) (Server, *Response, error) {
 	var trans Server
-
 	path := fmt.Sprintf("%s/%d", baseServerPath, serverID)
-	resp, err := s.client.MakeRequest("DELETE", path, nil, &trans)
 
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return Server{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -306,11 +363,16 @@ func (s *ServersClient) Delete(serverID int) (Server, *Response, error) {
 	return trans, resp, err
 }
 
-func (s *ServersClient) ListSSHKeys(serverID int, opts *GetOptions) ([]SSHKey, *Response, error) {
+func (s *ServersClient) ListSSHKeys(ctx context.Context, serverID int, opts *GetOptions) ([]SSHKey, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("%s/%d/ssh-keys", baseServerPath, serverID))
-
 	var trans []SSHKey
-	resp, err := s.client.MakeRequest("GET", path, nil, &trans)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -318,11 +380,16 @@ func (s *ServersClient) ListSSHKeys(serverID int, opts *GetOptions) ([]SSHKey, *
 	return trans, resp, err
 }
 
-func (s *ServersClient) ListCycles(opts *GetOptions) ([]ServerCycle, *Response, error) {
+func (s *ServersClient) ListCycles(ctx context.Context, opts *GetOptions) ([]ServerCycle, *Response, error) {
 	path := opts.WithQuery("cycles")
-
 	var trans []ServerCycle
-	resp, err := s.client.MakeRequest("GET", path, nil, &trans)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}

--- a/servers_test.go
+++ b/servers_test.go
@@ -7,7 +7,54 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestServer_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expected := []Server{{
+		ID:   383531,
+		Name: "E5-1620v4",
+		Href: "/servers/383531",
+		BMC: BMC{
+			User:     "kuser",
+			Password: "d564!h#4s8",
+		},
+		Hostname: "server-hostname",
+		Username: "user",
+		Password: "hjas345dgf54",
+		Image:    "Ubuntu 18.04 64bit",
+		Region: Region{
+			ID:         1,
+			Name:       "EU-Nord-1",
+			RegionIso2: "LT",
+			Href:       "/regions/1",
+		},
+		BGP: ServerBGP{
+			Enabled: true,
+		},
+		State: "active",
+		Tags:  map[string]string{"env": "dev"},
+	}}
+
+	mux.HandleFunc("GET /v1/projects/123/servers", func(writer http.ResponseWriter, request *http.Request) {
+		testMethod(t, request, http.MethodGet)
+
+		jsonBytes, _ := json.Marshal(expected)
+		response := string(jsonBytes)
+
+		fmt.Fprint(writer, response)
+	})
+
+	servers, _, err := testClient.Servers.List(t.Context(), 123, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, servers)
+}
 
 func TestServer_Get(t *testing.T) {
 	setup()
@@ -150,7 +197,6 @@ func TestServer_Create(t *testing.T) {
 	}
 
 	server, _, err := testClient.Servers.Create(t.Context(), &serverCreate)
-
 	if err != nil {
 		t.Errorf("Server.Create returned %+v", err)
 	}
@@ -173,7 +219,6 @@ func TestServer_Delete(t *testing.T) {
 	})
 
 	_, _, err := testClient.Servers.Delete(t.Context(), 383531)
-
 	if err != nil {
 		t.Errorf("Server.Delete returned %+v", err)
 	}
@@ -210,7 +255,6 @@ func TestServer_PowerOn(t *testing.T) {
 	})
 
 	_, _, err := testClient.Servers.PowerOn(t.Context(), 383531)
-
 	if err != nil {
 		t.Errorf("Server.PowerOn returned %+v", err)
 	}
@@ -247,7 +291,6 @@ func TestServer_PowerOff(t *testing.T) {
 	})
 
 	_, _, err := testClient.Servers.PowerOff(t.Context(), 383531)
-
 	if err != nil {
 		t.Errorf("Server.PowerOff returned %+v", err)
 	}
@@ -284,7 +327,6 @@ func TestServer_Reboot(t *testing.T) {
 	})
 
 	_, _, err := testClient.Servers.Reboot(t.Context(), 383531)
-
 	if err != nil {
 		t.Errorf("Server.Reboot returned %+v", err)
 	}
@@ -449,7 +491,6 @@ func TestServer_Update(t *testing.T) {
 	}
 
 	server, _, err := testClient.Servers.Update(t.Context(), 383531, &serverUpdate)
-
 	if err != nil {
 		t.Errorf("Server.Update returned %+v", err)
 	}
@@ -457,4 +498,105 @@ func TestServer_Update(t *testing.T) {
 	if !reflect.DeepEqual(server, response) {
 		t.Errorf("Server.List returned %+v, expected %+v", server, response)
 	}
+}
+
+func TestServer_Reinstall(t *testing.T) {
+	setup()
+	defer teardown()
+
+	reinstallRequest := ReinstallServerFields{
+		Image:           "test-img",
+		Hostname:        "test-host",
+		Password:        "test-pass",
+		IPXE:            "test-ipxe",
+		SSHKeys:         []string{"123"},
+		UserData:        "test-user-data",
+		OSPartitionSize: 1,
+	}
+
+	mux.HandleFunc("POST /v1/servers/123/actions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		v := new(ReinstallServerFields)
+		err := json.NewDecoder(r.Body).Decode(v)
+		require.NoError(t, err)
+
+		assert.Equal(t, reinstallRequest, *v)
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id": 123, "deployed_image": {"slug": "test-img"}}`)
+	})
+
+	server, _, err := testClient.Servers.Reinstall(t.Context(), 123, &reinstallRequest)
+	require.NoError(t, err)
+
+	assert.Equal(t, 123, server.ID)
+	assert.Equal(t, "test-img", server.DeployedImage.Slug)
+}
+
+func TestServer_ListSSHKeys(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("GET /v1/servers/123/ssh-keys", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[{"id": 123, "label": "test-key"}]`)
+	})
+
+	keys, _, err := testClient.Servers.ListSSHKeys(t.Context(), 123, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 123, keys[0].ID)
+	assert.Equal(t, "test-key", keys[0].Label)
+}
+
+func TestServer_ListCycles(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("GET /cycles", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodGet)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[{"id": 123, "name": "test-name", "slug": "test-slug"}]`)
+	})
+
+	cycles, _, err := testClient.Servers.ListCycles(t.Context(), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 123, cycles[0].ID)
+	assert.Equal(t, "test-name", cycles[0].Name)
+	assert.Equal(t, "test-slug", cycles[0].Slug)
+}
+
+func TestServer_Upgrade(t *testing.T) {
+	setup()
+	defer teardown()
+
+	want := UpgradeServer{
+		ServerAction: ServerAction{Type: "upgrade"},
+		Plan:         "test-plan",
+	}
+
+	mux.HandleFunc("POST /v1/servers/123/actions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodPost)
+
+		w.WriteHeader(http.StatusCreated)
+
+		v := new(UpgradeServer)
+		err := json.NewDecoder(r.Body).Decode(v)
+		require.NoError(t, err)
+
+		assert.Equal(t, want, *v)
+
+		fmt.Fprint(w, `{"id": 123, "plan":{"id": 123, "slug": "test-plan"}}`)
+	})
+
+	server, _, err := testClient.Servers.Upgrade(t.Context(), 123, "test-plan")
+	require.NoError(t, err)
+
+	assert.Equal(t, 123, server.ID)
+	assert.Equal(t, want.Plan, server.Plan.Slug)
 }

--- a/servers_test.go
+++ b/servers_test.go
@@ -47,7 +47,7 @@ func TestServer_Get(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	server, _, err := testClient.Servers.Get(383531, nil)
+	server, _, err := testClient.Servers.Get(t.Context(), 383531, nil)
 	if err != nil {
 		t.Errorf("Servers.Get returned %+v", err)
 	}
@@ -74,7 +74,7 @@ func TestServer_PowerState(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	power, _, err := testClient.Servers.PowerState(383531)
+	power, _, err := testClient.Servers.PowerState(t.Context(), 383531)
 	if err != nil {
 		t.Errorf("Server.PowerState returned %+v", err)
 	}
@@ -149,7 +149,7 @@ func TestServer_Create(t *testing.T) {
 		Tags:        &tags,
 	}
 
-	server, _, err := testClient.Servers.Create(&serverCreate)
+	server, _, err := testClient.Servers.Create(t.Context(), &serverCreate)
 
 	if err != nil {
 		t.Errorf("Server.Create returned %+v", err)
@@ -172,7 +172,7 @@ func TestServer_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, _, err := testClient.Servers.Delete(383531)
+	_, _, err := testClient.Servers.Delete(t.Context(), 383531)
 
 	if err != nil {
 		t.Errorf("Server.Delete returned %+v", err)
@@ -209,7 +209,7 @@ func TestServer_PowerOn(t *testing.T) {
 		fmt.Fprint(writer, string(jsonBytes))
 	})
 
-	_, _, err := testClient.Servers.PowerOn(383531)
+	_, _, err := testClient.Servers.PowerOn(t.Context(), 383531)
 
 	if err != nil {
 		t.Errorf("Server.PowerOn returned %+v", err)
@@ -246,7 +246,7 @@ func TestServer_PowerOff(t *testing.T) {
 		fmt.Fprint(writer, string(jsonBytes))
 	})
 
-	_, _, err := testClient.Servers.PowerOff(383531)
+	_, _, err := testClient.Servers.PowerOff(t.Context(), 383531)
 
 	if err != nil {
 		t.Errorf("Server.PowerOff returned %+v", err)
@@ -283,7 +283,7 @@ func TestServer_Reboot(t *testing.T) {
 		fmt.Fprint(writer, string(jsonBytes))
 	})
 
-	_, _, err := testClient.Servers.Reboot(383531)
+	_, _, err := testClient.Servers.Reboot(t.Context(), 383531)
 
 	if err != nil {
 		t.Errorf("Server.Reboot returned %+v", err)
@@ -323,7 +323,7 @@ func TestServer_EnterRescueMode(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	_, _, err := testClient.Servers.EnterRescueMode(383531, &RescueServerFields{Password: "abcdef"})
+	_, _, err := testClient.Servers.EnterRescueMode(t.Context(), 383531, &RescueServerFields{Password: "abcdef"})
 	if err != nil {
 		t.Errorf("Server.EnterRescueMode returned %+v", err)
 	}
@@ -361,7 +361,7 @@ func TestServer_ExitRescueMode(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	_, _, err := testClient.Servers.ExitRescueMode(383531)
+	_, _, err := testClient.Servers.ExitRescueMode(t.Context(), 383531)
 	if err != nil {
 		t.Errorf("Server.ExitRescueMode returned %+v", err)
 	}
@@ -396,7 +396,7 @@ func TestServersClient_ResetBMCPassword(t *testing.T) {
 		fmt.Fprint(writer, string(jsonBytes))
 	})
 
-	if _, _, err := testClient.Servers.ResetBMCPassword(383531); err != nil {
+	if _, _, err := testClient.Servers.ResetBMCPassword(t.Context(), 383531); err != nil {
 		t.Errorf("Servers.ResetBMCPassword returned %+v", err)
 	}
 }
@@ -448,7 +448,7 @@ func TestServer_Update(t *testing.T) {
 		Hostname: "cherry.prod",
 	}
 
-	server, _, err := testClient.Servers.Update(383531, &serverUpdate)
+	server, _, err := testClient.Servers.Update(t.Context(), 383531, &serverUpdate)
 
 	if err != nil {
 		t.Errorf("Server.Update returned %+v", err)

--- a/servers_test.go
+++ b/servers_test.go
@@ -47,7 +47,7 @@ func TestServer_Get(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	server, _, err := client.Servers.Get(383531, nil)
+	server, _, err := testClient.Servers.Get(383531, nil)
 	if err != nil {
 		t.Errorf("Servers.Get returned %+v", err)
 	}
@@ -74,7 +74,7 @@ func TestServer_PowerState(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	power, _, err := client.Servers.PowerState(383531)
+	power, _, err := testClient.Servers.PowerState(383531)
 	if err != nil {
 		t.Errorf("Server.PowerState returned %+v", err)
 	}
@@ -149,7 +149,7 @@ func TestServer_Create(t *testing.T) {
 		Tags:        &tags,
 	}
 
-	server, _, err := client.Servers.Create(&serverCreate)
+	server, _, err := testClient.Servers.Create(&serverCreate)
 
 	if err != nil {
 		t.Errorf("Server.Create returned %+v", err)
@@ -172,7 +172,7 @@ func TestServer_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, _, err := client.Servers.Delete(383531)
+	_, _, err := testClient.Servers.Delete(383531)
 
 	if err != nil {
 		t.Errorf("Server.Delete returned %+v", err)
@@ -209,7 +209,7 @@ func TestServer_PowerOn(t *testing.T) {
 		fmt.Fprint(writer, string(jsonBytes))
 	})
 
-	_, _, err := client.Servers.PowerOn(383531)
+	_, _, err := testClient.Servers.PowerOn(383531)
 
 	if err != nil {
 		t.Errorf("Server.PowerOn returned %+v", err)
@@ -246,7 +246,7 @@ func TestServer_PowerOff(t *testing.T) {
 		fmt.Fprint(writer, string(jsonBytes))
 	})
 
-	_, _, err := client.Servers.PowerOff(383531)
+	_, _, err := testClient.Servers.PowerOff(383531)
 
 	if err != nil {
 		t.Errorf("Server.PowerOff returned %+v", err)
@@ -283,7 +283,7 @@ func TestServer_Reboot(t *testing.T) {
 		fmt.Fprint(writer, string(jsonBytes))
 	})
 
-	_, _, err := client.Servers.Reboot(383531)
+	_, _, err := testClient.Servers.Reboot(383531)
 
 	if err != nil {
 		t.Errorf("Server.Reboot returned %+v", err)
@@ -323,7 +323,7 @@ func TestServer_EnterRescueMode(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	_, _, err := client.Servers.EnterRescueMode(383531, &RescueServerFields{Password: "abcdef"})
+	_, _, err := testClient.Servers.EnterRescueMode(383531, &RescueServerFields{Password: "abcdef"})
 	if err != nil {
 		t.Errorf("Server.EnterRescueMode returned %+v", err)
 	}
@@ -361,7 +361,7 @@ func TestServer_ExitRescueMode(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	_, _, err := client.Servers.ExitRescueMode(383531)
+	_, _, err := testClient.Servers.ExitRescueMode(383531)
 	if err != nil {
 		t.Errorf("Server.ExitRescueMode returned %+v", err)
 	}
@@ -396,7 +396,7 @@ func TestServersClient_ResetBMCPassword(t *testing.T) {
 		fmt.Fprint(writer, string(jsonBytes))
 	})
 
-	if _, _, err := client.Servers.ResetBMCPassword(383531); err != nil {
+	if _, _, err := testClient.Servers.ResetBMCPassword(383531); err != nil {
 		t.Errorf("Servers.ResetBMCPassword returned %+v", err)
 	}
 }
@@ -448,7 +448,7 @@ func TestServer_Update(t *testing.T) {
 		Hostname: "cherry.prod",
 	}
 
-	server, _, err := client.Servers.Update(383531, &serverUpdate)
+	server, _, err := testClient.Servers.Update(383531, &serverUpdate)
 
 	if err != nil {
 		t.Errorf("Server.Update returned %+v", err)

--- a/sshkeys.go
+++ b/sshkeys.go
@@ -1,17 +1,21 @@
 package cherrygo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
 
 const baseSSHPath = "/v1/ssh-keys"
 
 // SSHKeysService is an interface for interfacing with the the SSH keys endpoints of the CherryServers API
 // See: https://api.cherryservers.com/doc/#tag/SshKeys
 type SSHKeysService interface {
-	List(opts *GetOptions) ([]SSHKey, *Response, error)
-	Get(sshKeyID int, opts *GetOptions) (SSHKey, *Response, error)
-	Create(request *CreateSSHKey) (SSHKey, *Response, error)
-	Delete(sshKeyID int) (SSHKey, *Response, error)
-	Update(sshKeyID int, request *UpdateSSHKey) (SSHKey, *Response, error)
+	List(ctx context.Context, opts *GetOptions) ([]SSHKey, *Response, error)
+	Get(ctx context.Context, sshKeyID int, opts *GetOptions) (SSHKey, *Response, error)
+	Create(ctx context.Context, request *CreateSSHKey) (SSHKey, *Response, error)
+	Delete(ctx context.Context, sshKeyID int) (SSHKey, *Response, error)
+	Update(ctx context.Context, sshKeyID int, request *UpdateSSHKey) (SSHKey, *Response, error)
 }
 
 // SSHKeys fields for return values after creation
@@ -43,11 +47,16 @@ type UpdateSSHKey struct {
 }
 
 // List all available ssh keys
-func (s *SSHKeysClient) List(opts *GetOptions) ([]SSHKey, *Response, error) {
+func (s *SSHKeysClient) List(ctx context.Context, opts *GetOptions) ([]SSHKey, *Response, error) {
 	var trans []SSHKey
-
 	pathQuery := opts.WithQuery(baseSSHPath)
-	resp, err := s.client.MakeRequest("GET", pathQuery, nil, &trans)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, pathQuery, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -55,12 +64,16 @@ func (s *SSHKeysClient) List(opts *GetOptions) ([]SSHKey, *Response, error) {
 	return trans, resp, err
 }
 
-func (s *SSHKeysClient) Get(sshKeyID int, opts *GetOptions) (SSHKey, *Response, error) {
+func (s *SSHKeysClient) Get(ctx context.Context, sshKeyID int, opts *GetOptions) (SSHKey, *Response, error) {
 	var trans SSHKey
-
 	path := opts.WithQuery(fmt.Sprintf("%s/%d", baseSSHPath, sshKeyID))
 
-	resp, err := s.client.MakeRequest("GET", path, nil, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return SSHKey{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -69,10 +82,15 @@ func (s *SSHKeysClient) Get(sshKeyID int, opts *GetOptions) (SSHKey, *Response, 
 }
 
 // Create adds new SSH key
-func (s *SSHKeysClient) Create(request *CreateSSHKey) (SSHKey, *Response, error) {
+func (s *SSHKeysClient) Create(ctx context.Context, request *CreateSSHKey) (SSHKey, *Response, error) {
 	var trans SSHKey
 
-	resp, err := s.client.MakeRequest("POST", baseSSHPath, request, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, baseSSHPath, request)
+	if err != nil {
+		return SSHKey{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -81,12 +99,16 @@ func (s *SSHKeysClient) Create(request *CreateSSHKey) (SSHKey, *Response, error)
 }
 
 // Delete removes desired SSH key by its ID
-func (s *SSHKeysClient) Delete(sshKeyID int) (SSHKey, *Response, error) {
+func (s *SSHKeysClient) Delete(ctx context.Context, sshKeyID int) (SSHKey, *Response, error) {
 	var trans SSHKey
-
 	path := fmt.Sprintf("%s/%d", baseSSHPath, sshKeyID)
 
-	resp, err := s.client.MakeRequest("DELETE", path, nil, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return SSHKey{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -95,12 +117,16 @@ func (s *SSHKeysClient) Delete(sshKeyID int) (SSHKey, *Response, error) {
 }
 
 // Update function updates keys Label or key itself
-func (s *SSHKeysClient) Update(sshKeyID int, request *UpdateSSHKey) (SSHKey, *Response, error) {
+func (s *SSHKeysClient) Update(ctx context.Context, sshKeyID int, request *UpdateSSHKey) (SSHKey, *Response, error) {
 	var trans SSHKey
-
 	path := fmt.Sprintf("%s/%d", baseSSHPath, sshKeyID)
 
-	resp, err := s.client.MakeRequest("PUT", path, request, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodPut, path, request)
+	if err != nil {
+		return SSHKey{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}

--- a/sshkeys_test.go
+++ b/sshkeys_test.go
@@ -6,7 +6,39 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestSSHKey_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expected := []SSHKey{{
+		ID:          1,
+		Label:       "test",
+		Key:         "ssh-rsa AAAAB3NzaC1yc",
+		Fingerprint: "fb:f0:21:33:e9:26:y3:2e:2e:b4:5c:8a:a6:26:64:ae",
+		Updated:     "2021-04-20 16:40:54",
+		Created:     "2021-04-20 13:40:43",
+		Href:        "/ssh-keys/1",
+	}}
+
+	mux.HandleFunc("GET /v1/ssh-keys", func(writer http.ResponseWriter, request *http.Request) {
+		testMethod(t, request, http.MethodGet)
+
+		jsonBytes, _ := json.Marshal(expected)
+		response := string(jsonBytes)
+
+		fmt.Fprint(writer, response)
+	})
+
+	sshKey, _, err := testClient.SSHKeys.List(t.Context(), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, sshKey)
+}
 
 func TestSSHKey_Get(t *testing.T) {
 	setup()
@@ -33,11 +65,11 @@ func TestSSHKey_Get(t *testing.T) {
 
 	sshKey, _, err := testClient.SSHKeys.Get(t.Context(), 1, nil)
 	if err != nil {
-		t.Errorf("SSHKey.List returned %+v", err)
+		t.Errorf("SSHKey.Get returned %+v", err)
 	}
 
 	if !reflect.DeepEqual(sshKey, expected) {
-		t.Errorf("SSHKey.List returned %+v, expected %+v", sshKey, expected)
+		t.Errorf("SSHKey.Get returned %+v, expected %+v", sshKey, expected)
 	}
 }
 

--- a/sshkeys_test.go
+++ b/sshkeys_test.go
@@ -31,7 +31,7 @@ func TestSSHKey_Get(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	sshKey, _, err := testClient.SSHKeys.Get(1, nil)
+	sshKey, _, err := testClient.SSHKeys.Get(t.Context(), 1, nil)
 	if err != nil {
 		t.Errorf("SSHKey.List returned %+v", err)
 	}
@@ -83,7 +83,7 @@ func TestSSHKey_Create(t *testing.T) {
 		Key:   "ssh-rsa AAAAB3NzaC1yc",
 	}
 
-	_, _, err := testClient.SSHKeys.Create(&sshCreate)
+	_, _, err := testClient.SSHKeys.Create(t.Context(), &sshCreate)
 
 	if err != nil {
 		t.Errorf("SSHKey.Create returned %+v", err)
@@ -102,7 +102,7 @@ func TestSSHKey_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, _, err := testClient.SSHKeys.Delete(1)
+	_, _, err := testClient.SSHKeys.Delete(t.Context(), 1)
 
 	if err != nil {
 		t.Errorf("SSHKey.Delete returned %+v", err)
@@ -148,7 +148,7 @@ func TestSSHKey_Update(t *testing.T) {
 		Key:   &key,
 	}
 
-	_, _, err := testClient.SSHKeys.Update(1, &sshUpdate)
+	_, _, err := testClient.SSHKeys.Update(t.Context(), 1, &sshUpdate)
 
 	if err != nil {
 		t.Errorf("SSHKey.Update returned %+v", err)

--- a/sshkeys_test.go
+++ b/sshkeys_test.go
@@ -31,7 +31,7 @@ func TestSSHKey_Get(t *testing.T) {
 		fmt.Fprint(writer, response)
 	})
 
-	sshKey, _, err := client.SSHKeys.Get(1, nil)
+	sshKey, _, err := testClient.SSHKeys.Get(1, nil)
 	if err != nil {
 		t.Errorf("SSHKey.List returned %+v", err)
 	}
@@ -83,7 +83,7 @@ func TestSSHKey_Create(t *testing.T) {
 		Key:   "ssh-rsa AAAAB3NzaC1yc",
 	}
 
-	_, _, err := client.SSHKeys.Create(&sshCreate)
+	_, _, err := testClient.SSHKeys.Create(&sshCreate)
 
 	if err != nil {
 		t.Errorf("SSHKey.Create returned %+v", err)
@@ -102,7 +102,7 @@ func TestSSHKey_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, _, err := client.SSHKeys.Delete(1)
+	_, _, err := testClient.SSHKeys.Delete(1)
 
 	if err != nil {
 		t.Errorf("SSHKey.Delete returned %+v", err)
@@ -148,7 +148,7 @@ func TestSSHKey_Update(t *testing.T) {
 		Key:   &key,
 	}
 
-	_, _, err := client.SSHKeys.Update(1, &sshUpdate)
+	_, _, err := testClient.SSHKeys.Update(1, &sshUpdate)
 
 	if err != nil {
 		t.Errorf("SSHKey.Update returned %+v", err)

--- a/storages.go
+++ b/storages.go
@@ -1,7 +1,9 @@
 package cherrygo
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 )
 
 const baseStoragePath = "/v1/storages"
@@ -9,13 +11,13 @@ const baseStoragePath = "/v1/storages"
 // StoragesService is an interface for interfacing with the Storages endpoints of the CherryServers API
 // See: https://api.cherryservers.com/doc/#tag/Storage
 type StoragesService interface {
-	List(projectID int, opts *GetOptions) ([]BlockStorage, *Response, error)
-	Get(storageID int, opts *GetOptions) (BlockStorage, *Response, error)
-	Create(request *CreateStorage) (BlockStorage, *Response, error)
-	Delete(storageID int) (*Response, error)
-	Attach(request *AttachTo) (BlockStorage, *Response, error)
-	Detach(storageID int) (*Response, error)
-	Update(request *UpdateStorage) (BlockStorage, *Response, error)
+	List(ctx context.Context, projectID int, opts *GetOptions) ([]BlockStorage, *Response, error)
+	Get(ctx context.Context, storageID int, opts *GetOptions) (BlockStorage, *Response, error)
+	Create(ctx context.Context, request *CreateStorage) (BlockStorage, *Response, error)
+	Delete(ctx context.Context, storageID int) (*Response, error)
+	Attach(ctx context.Context, request *AttachTo) (BlockStorage, *Response, error)
+	Detach(ctx context.Context, storageID int) (*Response, error)
+	Update(ctx context.Context, request *UpdateStorage) (BlockStorage, *Response, error)
 }
 
 type BlockStorage struct {
@@ -66,11 +68,16 @@ type StoragesClient struct {
 	client *Client
 }
 
-func (c *StoragesClient) List(projectID int, opts *GetOptions) ([]BlockStorage, *Response, error) {
+func (s *StoragesClient) List(ctx context.Context, projectID int, opts *GetOptions) ([]BlockStorage, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("%s/%d/storages", baseProjectPath, projectID))
-
 	var trans []BlockStorage
-	resp, err := c.client.MakeRequest("GET", path, nil, &trans)
+
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -78,12 +85,16 @@ func (c *StoragesClient) List(projectID int, opts *GetOptions) ([]BlockStorage, 
 	return trans, resp, err
 }
 
-func (s *StoragesClient) Get(storageID int, opts *GetOptions) (BlockStorage, *Response, error) {
+func (s *StoragesClient) Get(ctx context.Context, storageID int, opts *GetOptions) (BlockStorage, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("%s/%d", baseStoragePath, storageID))
-
 	var trans BlockStorage
 
-	resp, err := s.client.MakeRequest("GET", path, nil, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return BlockStorage{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -91,12 +102,16 @@ func (s *StoragesClient) Get(storageID int, opts *GetOptions) (BlockStorage, *Re
 	return trans, resp, err
 }
 
-func (s *StoragesClient) Create(request *CreateStorage) (BlockStorage, *Response, error) {
+func (s *StoragesClient) Create(ctx context.Context, request *CreateStorage) (BlockStorage, *Response, error) {
 	var trans BlockStorage
-
 	path := fmt.Sprintf("%s/%d/storages", baseProjectPath, request.ProjectID)
 
-	resp, err := s.client.MakeRequest("POST", path, request, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return BlockStorage{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -104,10 +119,15 @@ func (s *StoragesClient) Create(request *CreateStorage) (BlockStorage, *Response
 	return trans, resp, err
 }
 
-func (s *StoragesClient) Delete(storageID int) (*Response, error) {
+func (s *StoragesClient) Delete(ctx context.Context, storageID int) (*Response, error) {
 	path := fmt.Sprintf("%s/%d", baseStoragePath, storageID)
 
-	resp, err := s.client.MakeRequest("DELETE", path, nil, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -115,12 +135,16 @@ func (s *StoragesClient) Delete(storageID int) (*Response, error) {
 	return resp, err
 }
 
-func (s *StoragesClient) Attach(request *AttachTo) (BlockStorage, *Response, error) {
+func (s *StoragesClient) Attach(ctx context.Context, request *AttachTo) (BlockStorage, *Response, error) {
 	var trans BlockStorage
-
 	path := fmt.Sprintf("%s/%d/attachments", baseStoragePath, request.StorageID)
 
-	resp, err := s.client.MakeRequest("POST", path, request, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return BlockStorage{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -128,10 +152,15 @@ func (s *StoragesClient) Attach(request *AttachTo) (BlockStorage, *Response, err
 	return trans, resp, err
 }
 
-func (s *StoragesClient) Detach(storageID int) (*Response, error) {
+func (s *StoragesClient) Detach(ctx context.Context, storageID int) (*Response, error) {
 	path := fmt.Sprintf("%s/%d/attachments", baseStoragePath, storageID)
 
-	resp, err := s.client.MakeRequest("DELETE", path, nil, nil)
+	req, err := s.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Do(req, nil)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -139,12 +168,16 @@ func (s *StoragesClient) Detach(storageID int) (*Response, error) {
 	return resp, err
 }
 
-func (s *StoragesClient) Update(request *UpdateStorage) (BlockStorage, *Response, error) {
+func (s *StoragesClient) Update(ctx context.Context, request *UpdateStorage) (BlockStorage, *Response, error) {
 	var trans BlockStorage
-
 	path := fmt.Sprintf("%s/%d", baseStoragePath, request.StorageID)
 
-	resp, err := s.client.MakeRequest("PUT", path, request, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodPut, path, request)
+	if err != nil {
+		return BlockStorage{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}

--- a/storages_test.go
+++ b/storages_test.go
@@ -9,6 +9,57 @@ import (
 	"testing"
 )
 
+func TestStorage_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expected := []BlockStorage{{
+		ID:            123,
+		Name:          "name",
+		Href:          "/storages/123",
+		Size:          256,
+		AllowEditSize: true,
+		Unit:          "GB",
+		Description:   "string",
+		AttachedTo: AttachedTo{
+			Href: "/servers/1",
+		},
+		VlanID:      "1",
+		VlanIP:      "1.1.1.1",
+		Initiator:   "com.cherryservers:initiator",
+		DiscoveryIP: "1.1.1.1",
+	}}
+
+	mux.HandleFunc("GET /v1/projects/123/storages", func(writer http.ResponseWriter, request *http.Request) {
+		testMethod(t, request, http.MethodGet)
+		fmt.Fprint(writer, `[{
+			"id": 123,
+			"name": "name",
+			"href": "/storages/123",
+			"size": 256,
+			"allow_edit_size": true,
+			"unit": "GB",
+			"description": "string",
+			"attached_to": {
+				"href": "/servers/1"
+			},
+			"vlan_id": "1",
+			"vlan_ip": "1.1.1.1",
+			"initiator": "com.cherryservers:initiator",
+			"discovery_ip": "1.1.1.1"
+		}]`)
+	})
+
+	storages, _, err := testClient.Storages.List(t.Context(), 123, nil)
+	if err != nil {
+		t.Errorf("Storages.List returned %+v", err)
+	}
+
+	if !reflect.DeepEqual(storages, expected) {
+		t.Errorf("Storages.List returned %+v, expected %+v", storages, expected)
+	}
+}
+
 func TestStorage_Get(t *testing.T) {
 	setup()
 	defer teardown()
@@ -52,11 +103,11 @@ func TestStorage_Get(t *testing.T) {
 
 	storage, _, err := testClient.Storages.Get(t.Context(), 123, nil)
 	if err != nil {
-		t.Errorf("Storage.List returned %+v", err)
+		t.Errorf("Storages.Get returned %+v", err)
 	}
 
 	if !reflect.DeepEqual(storage, expected) {
-		t.Errorf("Storage.List returned %+v, expected %+v", storage, expected)
+		t.Errorf("Storages.Get returned %+v, expected %+v", storage, expected)
 	}
 }
 
@@ -96,7 +147,7 @@ func TestStorage_Create(t *testing.T) {
 
 	_, _, err := testClient.Storages.Create(t.Context(), &createStorage)
 	if err != nil {
-		t.Errorf("Storage.List returned %+v", err)
+		t.Errorf("Storages.Create returned %+v", err)
 	}
 }
 
@@ -112,7 +163,7 @@ func TestStorage_Delete(t *testing.T) {
 
 	_, err := testClient.Storages.Delete(t.Context(), 123)
 	if err != nil {
-		t.Errorf("Storage.Delete returned %+v", err)
+		t.Errorf("Storages.Delete returned %+v", err)
 	}
 }
 
@@ -148,7 +199,7 @@ func TestStorage_Attach(t *testing.T) {
 
 	_, _, err := testClient.Storages.Attach(t.Context(), &attachStorage)
 	if err != nil {
-		t.Errorf("Storage.Attach returned %+v", err)
+		t.Errorf("Storages.Attach returned %+v", err)
 	}
 }
 
@@ -164,7 +215,7 @@ func TestStorage_Detach(t *testing.T) {
 
 	_, err := testClient.Storages.Detach(t.Context(), 123)
 	if err != nil {
-		t.Errorf("Storage.Detach returned %+v", err)
+		t.Errorf("Storages.Detach returned %+v", err)
 	}
 }
 
@@ -202,6 +253,6 @@ func TestStorage_Update(t *testing.T) {
 
 	_, _, err := testClient.Storages.Update(t.Context(), &updateStorage)
 	if err != nil {
-		t.Errorf("Storage.Update returned %+v", err)
+		t.Errorf("Storages.Update returned %+v", err)
 	}
 }

--- a/storages_test.go
+++ b/storages_test.go
@@ -50,7 +50,7 @@ func TestStorage_Get(t *testing.T) {
 		}`)
 	})
 
-	storage, _, err := client.Storages.Get(123, nil)
+	storage, _, err := testClient.Storages.Get(123, nil)
 	if err != nil {
 		t.Errorf("Storage.List returned %+v", err)
 	}
@@ -94,7 +94,7 @@ func TestStorage_Create(t *testing.T) {
 		Region:      "EU-Nord-1",
 	}
 
-	_, _, err := client.Storages.Create(&createStorage)
+	_, _, err := testClient.Storages.Create(&createStorage)
 	if err != nil {
 		t.Errorf("Storage.List returned %+v", err)
 	}
@@ -110,7 +110,7 @@ func TestStorage_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := client.Storages.Delete(123)
+	_, err := testClient.Storages.Delete(123)
 	if err != nil {
 		t.Errorf("Storage.Delete returned %+v", err)
 	}
@@ -146,7 +146,7 @@ func TestStorage_Attach(t *testing.T) {
 		AttachTo:  1234,
 	}
 
-	_, _, err := client.Storages.Attach(&attachStorage)
+	_, _, err := testClient.Storages.Attach(&attachStorage)
 	if err != nil {
 		t.Errorf("Storage.Attach returned %+v", err)
 	}
@@ -162,7 +162,7 @@ func TestStorage_Detach(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := client.Storages.Detach(123)
+	_, err := testClient.Storages.Detach(123)
 	if err != nil {
 		t.Errorf("Storage.Detach returned %+v", err)
 	}
@@ -200,7 +200,7 @@ func TestStorage_Update(t *testing.T) {
 		Description: "volume 1",
 	}
 
-	_, _, err := client.Storages.Update(&updateStorage)
+	_, _, err := testClient.Storages.Update(&updateStorage)
 	if err != nil {
 		t.Errorf("Storage.Update returned %+v", err)
 	}

--- a/storages_test.go
+++ b/storages_test.go
@@ -50,7 +50,7 @@ func TestStorage_Get(t *testing.T) {
 		}`)
 	})
 
-	storage, _, err := testClient.Storages.Get(123, nil)
+	storage, _, err := testClient.Storages.Get(t.Context(), 123, nil)
 	if err != nil {
 		t.Errorf("Storage.List returned %+v", err)
 	}
@@ -94,7 +94,7 @@ func TestStorage_Create(t *testing.T) {
 		Region:      "EU-Nord-1",
 	}
 
-	_, _, err := testClient.Storages.Create(&createStorage)
+	_, _, err := testClient.Storages.Create(t.Context(), &createStorage)
 	if err != nil {
 		t.Errorf("Storage.List returned %+v", err)
 	}
@@ -110,7 +110,7 @@ func TestStorage_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := testClient.Storages.Delete(123)
+	_, err := testClient.Storages.Delete(t.Context(), 123)
 	if err != nil {
 		t.Errorf("Storage.Delete returned %+v", err)
 	}
@@ -146,7 +146,7 @@ func TestStorage_Attach(t *testing.T) {
 		AttachTo:  1234,
 	}
 
-	_, _, err := testClient.Storages.Attach(&attachStorage)
+	_, _, err := testClient.Storages.Attach(t.Context(), &attachStorage)
 	if err != nil {
 		t.Errorf("Storage.Attach returned %+v", err)
 	}
@@ -162,7 +162,7 @@ func TestStorage_Detach(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := testClient.Storages.Detach(123)
+	_, err := testClient.Storages.Detach(t.Context(), 123)
 	if err != nil {
 		t.Errorf("Storage.Detach returned %+v", err)
 	}
@@ -200,7 +200,7 @@ func TestStorage_Update(t *testing.T) {
 		Description: "volume 1",
 	}
 
-	_, _, err := testClient.Storages.Update(&updateStorage)
+	_, _, err := testClient.Storages.Update(t.Context(), &updateStorage)
 	if err != nil {
 		t.Errorf("Storage.Update returned %+v", err)
 	}

--- a/teams.go
+++ b/teams.go
@@ -1,17 +1,21 @@
 package cherrygo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
 
 const teamsPath = "/v1/teams"
 
 // TeamsService is an interface for interfacing with the Teams endpoints of the CherryServers API
 // See: https://api.cherryservers.com/doc/#tag/Teams
 type TeamsService interface {
-	List(opts *GetOptions) ([]Team, *Response, error)
-	Get(teamID int, opts *GetOptions) (Team, *Response, error)
-	Create(request *CreateTeam) (Team, *Response, error)
-	Update(teamID int, request *UpdateTeam) (Team, *Response, error)
-	Delete(teamID int) (*Response, error)
+	List(ctx context.Context, opts *GetOptions) ([]Team, *Response, error)
+	Get(ctx context.Context, teamID int, opts *GetOptions) (Team, *Response, error)
+	Create(ctx context.Context, request *CreateTeam) (Team, *Response, error)
+	Update(ctx context.Context, teamID int, request *UpdateTeam) (Team, *Response, error)
+	Delete(ctx context.Context, teamID int) (*Response, error)
 }
 
 type Team struct {
@@ -91,11 +95,16 @@ type UpdateTeam struct {
 }
 
 // List func lists teams
-func (t *TeamsClient) List(opts *GetOptions) ([]Team, *Response, error) {
+func (c *TeamsClient) List(ctx context.Context, opts *GetOptions) ([]Team, *Response, error) {
 	var trans []Team
-
 	pathQuery := opts.WithQuery(teamsPath)
-	resp, err := t.client.MakeRequest("GET", pathQuery, nil, &trans)
+
+	req, err := c.client.NewRequest(ctx, http.MethodGet, pathQuery, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp, err := c.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -103,12 +112,16 @@ func (t *TeamsClient) List(opts *GetOptions) ([]Team, *Response, error) {
 	return trans, resp, err
 }
 
-func (p *TeamsClient) Get(teamID int, opts *GetOptions) (Team, *Response, error) {
+func (c *TeamsClient) Get(ctx context.Context, teamID int, opts *GetOptions) (Team, *Response, error) {
 	path := opts.WithQuery(fmt.Sprintf("%s/%d", teamsPath, teamID))
-
 	var trans Team
 
-	resp, err := p.client.MakeRequest("GET", path, nil, &trans)
+	req, err := c.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return Team{}, nil, err
+	}
+
+	resp, err := c.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -116,12 +129,16 @@ func (p *TeamsClient) Get(teamID int, opts *GetOptions) (Team, *Response, error)
 	return trans, resp, err
 }
 
-func (p *TeamsClient) Create(request *CreateTeam) (Team, *Response, error) {
+func (c *TeamsClient) Create(ctx context.Context, request *CreateTeam) (Team, *Response, error) {
 	path := fmt.Sprintf("%s", teamsPath)
-
 	var trans Team
 
-	resp, err := p.client.MakeRequest("POST", path, request, &trans)
+	req, err := c.client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return Team{}, nil, err
+	}
+
+	resp, err := c.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -129,12 +146,16 @@ func (p *TeamsClient) Create(request *CreateTeam) (Team, *Response, error) {
 	return trans, resp, err
 }
 
-func (p *TeamsClient) Update(teamID int, request *UpdateTeam) (Team, *Response, error) {
+func (c *TeamsClient) Update(ctx context.Context, teamID int, request *UpdateTeam) (Team, *Response, error) {
 	path := fmt.Sprintf("%s/%d", teamsPath, teamID)
-
 	var trans Team
 
-	resp, err := p.client.MakeRequest("PUT", path, request, &trans)
+	req, err := c.client.NewRequest(ctx, http.MethodPut, path, request)
+	if err != nil {
+		return Team{}, nil, err
+	}
+
+	resp, err := c.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -142,10 +163,15 @@ func (p *TeamsClient) Update(teamID int, request *UpdateTeam) (Team, *Response, 
 	return trans, resp, err
 }
 
-func (p *TeamsClient) Delete(teamID int) (*Response, error) {
+func (c *TeamsClient) Delete(ctx context.Context, teamID int) (*Response, error) {
 	path := fmt.Sprintf("%s/%d", teamsPath, teamID)
 
-	resp, err := p.client.MakeRequest("DELETE", path, nil, nil)
+	req, err := c.client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.client.Do(req, nil)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}

--- a/teams_test.go
+++ b/teams_test.go
@@ -16,7 +16,7 @@ func TestTeam_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := testClient.Teams.Delete(123)
+	_, err := testClient.Teams.Delete(t.Context(), 123)
 	if err != nil {
 		t.Errorf("Teams.Delete returned %+v", err)
 	}

--- a/teams_test.go
+++ b/teams_test.go
@@ -16,7 +16,7 @@ func TestTeam_Delete(t *testing.T) {
 		fmt.Fprint(writer)
 	})
 
-	_, err := client.Teams.Delete(123)
+	_, err := testClient.Teams.Delete(123)
 	if err != nil {
 		t.Errorf("Teams.Delete returned %+v", err)
 	}

--- a/teams_test.go
+++ b/teams_test.go
@@ -1,9 +1,13 @@
 package cherrygo
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTeam_Delete(t *testing.T) {
@@ -17,7 +21,229 @@ func TestTeam_Delete(t *testing.T) {
 	})
 
 	_, err := testClient.Teams.Delete(t.Context(), 123)
-	if err != nil {
-		t.Errorf("Teams.Delete returned %+v", err)
+	assert.NoError(t, err)
+}
+
+func TestTeam_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	want := []Team{
+		{
+			ID:   123,
+			Name: "team",
+			Credit: Credit{
+				Account: CreditDetails{
+					Currency: "EUR",
+				},
+				Promo: CreditDetails{
+					Remaining: 969.69,
+					Usage:     189.72,
+					Currency:  "EUR",
+				},
+			},
+		},
 	}
+
+	mux.HandleFunc("/v1/teams", func(writer http.ResponseWriter, request *http.Request) {
+		testMethod(t, request, http.MethodGet)
+		writer.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(writer, `[{
+				"id":123,
+				"name": "team",
+				"credit": {
+      				"account": {
+       	 				"currency": "EUR"
+      				},
+					"promo": {
+						"remaining": 969.69,
+						"usage": 189.72,
+						"currency": "EUR"
+					}
+				}
+			 }]`)
+	})
+
+	team, _, err := testClient.Teams.List(t.Context(), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, want, team)
+}
+
+func TestTeam_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	want := Team{
+		ID:   123,
+		Name: "team",
+		Credit: Credit{
+			Account: CreditDetails{
+				Currency: "EUR",
+			},
+			Promo: CreditDetails{
+				Remaining: 969.48,
+				Usage:     189.93,
+				Currency:  "EUR",
+			},
+			Resources: Resources{
+				Pricing: Pricing{
+					Price:     0.2853,
+					UnitPrice: 0,
+					Taxed:     true,
+					Currency:  "EUR",
+					Unit:      "Hourly",
+				},
+				Remaining: RemainingTime{
+					Time: 4107,
+					Unit: "Hourly",
+				},
+			},
+		},
+		Billing: Billing{
+			Type:        "personal",
+			LastName:    "['test.test', 'cherryservers.com']",
+			CountryIso2: "LT",
+			Vat: Vat{
+				Amount: 21,
+				Valid:  false,
+			},
+			Currency: "EUR",
+		},
+		Href: "/teams/148226",
+	}
+
+	mux.HandleFunc("/v1/teams/123", func(writer http.ResponseWriter, request *http.Request) {
+		testMethod(t, request, http.MethodGet)
+		writer.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(writer, `{
+					"id": 123,
+					"name": "team",
+					"credit": {
+						"account": {
+						"currency": "EUR"
+						},
+						"promo": {
+						"remaining": 969.48,
+						"usage": 189.93,
+						"currency": "EUR"
+						},
+						"resources": {
+						"pricing": {
+							"price": 0.2853,
+							"unit_price": 0,
+							"taxed": true,
+							"currency": "EUR",
+							"unit": "Hourly"
+						},
+						"remaining": {
+							"time": 4107,
+							"unit": "Hourly"
+						}
+						}
+					},
+					"billing": {
+						"type": "personal",
+						"last_name": "['test.test', 'cherryservers.com']",
+						"country_iso_2": "LT",
+						"vat": {
+						"amount": 21,
+						"valid": false
+						},
+						"currency": "EUR"
+					},
+					"href": "/teams/148226"
+					}
+		`)
+	})
+
+	team, _, err := testClient.Teams.Get(t.Context(), 123, nil)
+
+	require.NoError(t, err)
+
+	assert.Equal(t, want, team)
+}
+
+func TestTeam_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	want := Team{
+		ID:   123,
+		Name: "team",
+	}
+
+	createRequest := CreateTeam{
+		Name:     "team",
+		Type:     "personal",
+		Currency: "EUR",
+	}
+
+	mux.HandleFunc("POST /v1/teams", func(writer http.ResponseWriter, request *http.Request) {
+		testMethod(t, request, http.MethodPost)
+		v := new(CreateTeam)
+		err := json.NewDecoder(request.Body).Decode(v)
+		require.NoError(t, err)
+
+		assert.Equal(t, createRequest, *v)
+
+		writer.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(writer, `{
+					"id": 123,
+					"name": "team"
+			}
+		`)
+	})
+
+	team, _, err := testClient.Teams.Create(t.Context(), &createRequest)
+	require.NoError(t, err)
+
+	assert.Equal(t, want, team)
+}
+
+func TestTeam_Update(t *testing.T) {
+	setup()
+	defer teardown()
+
+	want := Team{
+		ID:   123,
+		Name: "team",
+	}
+
+	var (
+		name = "team"
+		teamType = "personal"
+		currency = "EUR"
+	)
+
+	updateRequest := UpdateTeam{
+		Name:     &name,
+		Type:     &teamType,
+		Currency: &currency,
+	}
+
+	mux.HandleFunc("PUT /v1/teams/123", func(writer http.ResponseWriter, request *http.Request) {
+		testMethod(t, request, http.MethodPut)
+		v := new(UpdateTeam)
+		err := json.NewDecoder(request.Body).Decode(v)
+		require.NoError(t, err)
+
+		assert.Equal(t, updateRequest, *v)
+
+		writer.WriteHeader(http.StatusCreated)
+
+		fmt.Fprint(writer, `{
+					"id": 123,
+					"name": "team"
+			}
+		`)
+	})
+
+	team, _, err := testClient.Teams.Update(t.Context(), 123, &updateRequest)
+	require.NoError(t, err)
+
+	assert.Equal(t, want, team)
 }

--- a/users.go
+++ b/users.go
@@ -1,14 +1,18 @@
 package cherrygo
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
 
 const baseUserPath = "/v1/users"
 
 // UsersService is an interface for interfacing with the the User endpoints of the CherryServers API
 // See: https://api.cherryservers.com/doc/#tag/Users
 type UsersService interface {
-	CurrentUser(opts *GetOptions) (User, *Response, error)
-	Get(userID int, opts *GetOptions) (User, *Response, error)
+	CurrentUser(ctx context.Context, opts *GetOptions) (User, *Response, error)
+	Get(ctx context.Context, userID int, opts *GetOptions) (User, *Response, error)
 }
 
 type User struct {
@@ -27,12 +31,16 @@ type UsersClient struct {
 	client *Client
 }
 
-func (s *UsersClient) CurrentUser(opts *GetOptions) (User, *Response, error) {
+func (s *UsersClient) CurrentUser(ctx context.Context, opts *GetOptions) (User, *Response, error) {
 	var trans User
-
 	path := opts.WithQuery(fmt.Sprintf("/v1/user"))
 
-	resp, err := s.client.MakeRequest("GET", path, nil, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return User{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}
@@ -40,12 +48,16 @@ func (s *UsersClient) CurrentUser(opts *GetOptions) (User, *Response, error) {
 	return trans, resp, err
 }
 
-func (s *UsersClient) Get(userID int, opts *GetOptions) (User, *Response, error) {
+func (s *UsersClient) Get(ctx context.Context, userID int, opts *GetOptions) (User, *Response, error) {
 	var trans User
-
 	path := opts.WithQuery(fmt.Sprintf("%s/%d", baseUserPath, userID))
 
-	resp, err := s.client.MakeRequest("GET", path, nil, &trans)
+	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return User{}, nil, err
+	}
+
+	resp, err := s.client.Do(req, &trans)
 	if err != nil {
 		err = fmt.Errorf("Error: %v", err)
 	}

--- a/users_test.go
+++ b/users_test.go
@@ -45,3 +45,42 @@ func TestUser_Current(t *testing.T) {
 		t.Errorf("Users.CurrentUser returned %+v, expected %+v", user, expected)
 	}
 }
+
+func TestUser_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	expected := User{
+		ID:                    123,
+		FirstName:             "Ei",
+		LastName:              "Jei",
+		Email:                 "email@email.com",
+		EmailVerified:         true,
+		Phone:                 "37060000000",
+		SecurityPhone:         "37060000000",
+		SecurityPhoneVerified: false,
+	}
+
+	mux.HandleFunc("/v1/users/123", func(writer http.ResponseWriter, request *http.Request) {
+		testMethod(t, request, http.MethodGet)
+		fmt.Fprint(writer, `{
+				"id":123,
+				"first_name": "Ei",
+				"last_name": "Jei",
+				"email": "email@email.com",
+				"email_verified": true,
+				"phone": "37060000000",
+				"security_phone": "37060000000",
+				"security_phone_verified": false
+			 }`)
+	})
+
+	user, _, err := testClient.Users.Get(t.Context(), 123, nil)
+	if err != nil {
+		t.Errorf("Users.Get returned %+v", err)
+	}
+
+	if !reflect.DeepEqual(user, expected) {
+		t.Errorf("Users.Get returned %+v, expected %+v", user, expected)
+	}
+}

--- a/users_test.go
+++ b/users_test.go
@@ -36,7 +36,7 @@ func TestUser_Current(t *testing.T) {
 			 }`)
 	})
 
-	user, _, err := testClient.Users.CurrentUser(nil)
+	user, _, err := testClient.Users.CurrentUser(t.Context(), nil)
 	if err != nil {
 		t.Errorf("Users.CurrentUser returned %+v", err)
 	}

--- a/users_test.go
+++ b/users_test.go
@@ -36,7 +36,7 @@ func TestUser_Current(t *testing.T) {
 			 }`)
 	})
 
-	user, _, err := client.Users.CurrentUser(nil)
+	user, _, err := testClient.Users.CurrentUser(nil)
 	if err != nil {
 		t.Errorf("Users.CurrentUser returned %+v", err)
 	}


### PR DESCRIPTION
BREAKING CHANGE!

This is something that most provider SDKs do and is generally useful for controlling the lifetime of the request.
Also, improve unit test coverage by ensuring that every client method is covered with at least a happy path test.

Based on https://github.com/cherryservers/cherrygo/pull/76, so that should be merged first.