### PR TITLE
Add missing slash to current user request URL

### DIFF
--- a/users.go
+++ b/users.go
@@ -36,7 +36,7 @@ type UsersClient struct {
 // CurrentUser gets current user based on the API key.
 func (s *UsersClient) CurrentUser(ctx context.Context, opts *GetOptions) (User, *Response, error) {
 	var trans User
-	path := opts.WithQuery("v1/user")
+	path := opts.WithQuery("/v1/user")
 
 	req, err := s.client.NewRequest(ctx, http.MethodGet, path, nil)
 	if err != nil {


### PR DESCRIPTION
It would be better to use relative paths when building URLs, but that's a bigger refactor and I'd like to get `v4.0.0` out sooner rather than later at this point.