### PR TITLE
Add opts mutation warning for prebuilt plan listers

### DIFF
--- a/plans.go
+++ b/plans.go
@@ -182,6 +182,7 @@ func (p *PlansClient) listPrebuiltPlans(ctx context.Context, path, region string
 }
 
 // ListPrebuiltPlans retrieves variations of the base plan that have pre-assembled stock.
+// Mutates opts to set the region query parameter.
 func (p *PlansClient) ListPrebuiltPlans(ctx context.Context, basePlan, region string, opts *GetOptions) ([]PrebuiltPlan, *Response, error) {
 	path := fmt.Sprintf("%s/%s/prebuilts", basePlanPath, basePlan)
 	return p.listPrebuiltPlans(ctx, path, region, opts)
@@ -189,6 +190,7 @@ func (p *PlansClient) ListPrebuiltPlans(ctx context.Context, basePlan, region st
 
 // ListPrebuiltTeamPlans retrieves variations of the base plan that have pre-assembled stock.
 // The pricing is adjusted according to your teams billing settings.
+// Mutates opts to set the region query parameter.
 func (p *PlansClient) ListPrebuiltTeamPlans(ctx context.Context, basePlan, region string, teamID int, opts *GetOptions) ([]PrebuiltPlan, *Response, error) {
 	path := fmt.Sprintf("%s/%d/plans/%s/prebuilts", teamPlanPath, teamID, basePlan)
 	return p.listPrebuiltPlans(ctx, path, region, opts)


### PR DESCRIPTION
It's unlikely that the caller will want to use the opts in a way that causes a conflict, so a warning should be fine. The alternative would be to make a deep clone of `opts` on every call.