### PR TITLE
feat: expose private VLAN ID on IPAddress

### DIFF
--- a/ipaddresses.go
+++ b/ipaddresses.go
@@ -38,6 +38,9 @@ type IPAddress struct {
 	Tags          *map[string]string `json:"tags,omitempty"`
 	DDoSScrubbing bool               `json:"ddos_scrubbing,omitempty"`
 	Href          string             `json:"href,omitempty"`
+
+	// Only available for private IPs.
+	VLANID int `json:"vlan_id,omitempty"`
 }
 
 // RoutedTo fields

--- a/ipaddresses_test.go
+++ b/ipaddresses_test.go
@@ -59,6 +59,10 @@ func TestIpAddresses_List(t *testing.T) {
 			ARecord:   "a-b",
 			Href:      "/ips/e84d6ae8-573c-ecf9-a01d-afc57f95e910",
 		},
+		{
+			ID:     "55fcd8f8-3916-d26e-523f-85a2a52b90bc",
+			VLANID: 1234,
+		},
 	}
 
 	mux.HandleFunc("/v1/projects/"+strconv.Itoa(projectID)+"/ips", func(writer http.ResponseWriter, request *http.Request) {

--- a/servers.go
+++ b/servers.go
@@ -100,7 +100,10 @@ type Server struct {
 	Backup           BackupStorage     `json:"backup_storage,omitempty"`
 	Created          string            `json:"created_at,omitempty"`
 	TerminationDate  string            `json:"termination_date,omitempty"`
-	VLAN             int               `json:"vlan,omitempty"`
+
+	// This is the ID of the public VLAN and is only set for bare-metal servers.
+	// See IPAddress.VLANID for the private VLAN ID.
+	VLAN int `json:"vlan,omitempty"`
 }
 
 // BMC data.


### PR DESCRIPTION
Adds VLANID to IPAddress, exposing the private VLAN ID for private IPs. Previously only Server.VLAN existed, but that field represents a different thing — the public VLAN ID, which is only set for bare-metal servers. Both fields now coexist with doc comments cross-referencing each other so the distinction is clear:

Server.VLAN — public IP VLAN ID, bare-metal servers only
IPAddress.VLANID — private IP VLAN ID