### PR TITLE
fix: check if cap is reached before calculating jitter

### DIFF
--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -38,10 +38,16 @@ func RateLimitedExponentialBackoff(cfg ExponentialBackoffConfig) Func {
 func ExponentialBackoff(cfg ExponentialBackoffConfig) Func {
 	return func(attempts int, _ *http.Response) time.Duration {
 		backoffSeconds := cfg.Base.Seconds() * math.Pow(cfg.Multiplier, float64(attempts))
-		backoff := time.Second * time.Duration(backoffSeconds)
-		backoff = jitter(backoff)
 
-		return min(backoff, cfg.Cap)
+		// Guard against overflow on high iterations.
+		if math.IsNaN(backoffSeconds) ||
+			math.IsInf(backoffSeconds, 0) ||
+			backoffSeconds <= 0 ||
+			backoffSeconds >= cfg.Cap.Seconds() {
+			return cfg.Cap
+		}
+		backoff := time.Duration(backoffSeconds * float64(time.Second))
+		return jitter(backoff)
 	}
 }
 

--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -85,3 +85,14 @@ func TestRateLimitedExponentialBackoff(t *testing.T) {
 		})
 	}
 }
+
+func TestExponentialBackoffNoOverflow(t *testing.T) {
+	fn := backoff.ExponentialBackoff(backoff.ExponentialBackoffConfig{
+		Base:       2 * time.Second,
+		Cap:        60 * time.Second,
+		Multiplier: 2,
+	})
+
+	got := fn(1000, nil)
+	assert.Equal(t, 60*time.Second, got)
+}


### PR DESCRIPTION
Otherwise, on high iterations, backoff becomes high enough to overflow and causes a panic, when `Int64N()` is called with a negative value.