### PR TITLE
feat: add persist_ipxe field for server creation and re-installation

### DIFF
--- a/servers.go
+++ b/servers.go
@@ -140,6 +140,12 @@ type ReinstallServerFields struct {
 	SSHKeys         []string `json:"ssh_keys,omitempty"`
 	UserData        string   `json:"user_data,omitempty"`
 	OSPartitionSize int      `json:"os_partition_size,omitempty"`
+
+	// PersistIPXE enables persisting the universal iPXE image between server boots.
+	// See the [product docs] for more on how Cherry Servers implements iPXE support.
+	//
+	// [product docs]: https://www.cherryservers.com/knowledge/docs/compute/configuration-management/ipxe#how-ipxe-works-with-cherry-servers
+	PersistIPXE bool `json:"persist_ipxe"`
 }
 
 type rescueServer struct {
@@ -196,6 +202,12 @@ type CreateServer struct {
 	Cycle           string             `json:"cycle,omitempty"`
 	DiscountCode    string             `json:"discount,omitempty"`
 	ConfigureIPv6   *bool              `json:"configure_ipv6,omitempty"`
+
+	// PersistIPXE enables persisting the universal iPXE image between server boots.
+	// See the [product docs] for more on how Cherry Servers implements iPXE support.
+	//
+	// [product docs]: https://www.cherryservers.com/knowledge/docs/compute/configuration-management/ipxe#how-ipxe-works-with-cherry-servers
+	PersistIPXE bool `json:"persist_ipxe"`
 }
 
 // UpdateServer fields for updating a server with specified tags

--- a/servers_test.go
+++ b/servers_test.go
@@ -176,6 +176,7 @@ func TestServer_Create(t *testing.T) {
 		"tags":           map[string]interface{}{"env": "dev"},
 		"spot_market":    false,
 		"configure_ipv6": false,
+		"persist_ipxe":   true,
 	}
 
 	mux.HandleFunc("/v1/projects/"+strconv.Itoa(projectID)+"/servers", func(writer http.ResponseWriter, request *http.Request) {
@@ -210,6 +211,7 @@ func TestServer_Create(t *testing.T) {
 		UserData:      "dXNlcl9kYXRh",
 		Tags:          &tags,
 		ConfigureIPv6: new(bool),
+		PersistIPXE:   true,
 	}
 
 	server, _, err := testClient.Servers.Create(t.Context(), &serverCreate)
@@ -579,6 +581,7 @@ func TestServer_Reinstall(t *testing.T) {
 		SSHKeys:         []string{"123"},
 		UserData:        "test-user-data",
 		OSPartitionSize: 1,
+		PersistIPXE:     true,
 	}
 
 	mux.HandleFunc("POST /v1/servers/123/actions", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Add support for the new API field that allows persisting the universal iPXE image between boots.