### PR TITLE
fix: return error when server deployment fails while waiting for status

### DIFF
--- a/servers.go
+++ b/servers.go
@@ -35,11 +35,15 @@ const (
 	// iPXE, since these don't go through the full standard deployment
 	// process.
 	StatusAllocated
+
+	// StatusFailed is an internal Cherry Servers deployment failure.
+	StatusFailed
 )
 
 var serverStatusValues = map[ServerStatus]string{
 	StatusDeployed:  "deployed",
 	StatusAllocated: "allocated",
+	StatusFailed:    "failed deployment",
 }
 
 func (ss ServerStatus) String() string {
@@ -455,6 +459,7 @@ func (s *ServersClient) ListCycles(ctx context.Context, opts *GetOptions) ([]Ser
 }
 
 // WaitForStatus blocks until server reaches specified status.
+// Returns an error if the server has a failing status.
 func (s *ServersClient) WaitForStatus(ctx context.Context, serverID int, status ServerStatus) (Server, *Response, error) {
 	if s.client.pollBackoff == nil {
 		return Server{}, nil, errors.New("nil client pollBackoff function")
@@ -464,22 +469,23 @@ func (s *ServersClient) WaitForStatus(ctx context.Context, serverID int, status 
 	for {
 		server, resp, err := s.Get(ctx, serverID, nil)
 		if err != nil {
-			return Server{}, nil, err
+			return Server{}, resp, err
 		}
 
 		if server.Status == status.String() {
 			return server, resp, nil
 		}
 
-		if resp == nil {
-			return Server{}, nil, fmt.Errorf("nil response from GET server %d", serverID)
+		if server.Status == StatusFailed.String() {
+			err = fmt.Errorf("server %d deployment failed, contact support for assistance", serverID)
+			return server, resp, err
 		}
 
 		select {
 		case <-time.After(s.client.pollBackoff(attempt, resp.Response)):
 			attempt++
 		case <-ctx.Done():
-			return Server{}, nil, ctx.Err()
+			return Server{}, resp, ctx.Err()
 		}
 	}
 }

--- a/servers_test.go
+++ b/servers_test.go
@@ -751,6 +751,44 @@ func TestServer_WaitForStatusFailsWhenContextCancelled(t *testing.T) {
 	assert.Equal(t, 2, pollCount)
 }
 
+func TestServer_WaitForStatusReturnsErrorWhenDeploymentFails(t *testing.T) {
+	mux := http.NewServeMux()
+	apiServer := httptest.NewServer(mux)
+	defer apiServer.Close()
+
+	ctx := t.Context()
+
+	var pollF backoff.Func = func(_ int, _ *http.Response) time.Duration {
+		return 0
+	}
+
+	client, err := NewClient(WithAPIKey(
+		"fakeKey"),
+		WithPollBackoff(pollF),
+		WithURL(apiServer.URL),
+	)
+	require.NoError(t, err)
+
+	pollCount := 0
+	mux.HandleFunc("GET /v1/servers/123", func(w http.ResponseWriter, _ *http.Request) {
+		var handleErr error
+		pollCount++
+		if pollCount > 2 {
+			_, handleErr = fmt.Fprint(w, `{"id": 123, "status": "failed deployment"}`)
+		} else {
+			_, handleErr = fmt.Fprint(w, `{"id": 123, "status": "deploying"}`)
+		}
+		require.NoError(t, handleErr)
+	})
+
+	srv, resp, err := client.Servers.WaitForStatus(ctx, 123, StatusDeployed)
+
+	assert.Error(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, "failed deployment", srv.Status)
+	assert.Equal(t, 3, pollCount)
+}
+
 func TestGeneratePasswordGeneratesValidCherryServersPasswords(t *testing.T) {
 	const minLen = 16
 	var failures []string


### PR DESCRIPTION
Return an error if the server has a `failed deployment` status, in the server status waiter method.  This will prevent pointless polling after a deployment has failed.